### PR TITLE
Fix context discovery

### DIFF
--- a/completion/kubectx.bash
+++ b/completion/kubectx.bash
@@ -2,7 +2,7 @@ _kube_contexts()
 {
   local curr_arg;
   curr_arg=${COMP_WORDS[COMP_CWORD]}
-  COMPREPLY=( $(compgen -W "- $(kubectl config get-contexts | awk '{print $2}' | tail -n +2)" -- $curr_arg ) );
+  COMPREPLY=( $(compgen -W "- $(kubectl config get-contexts --output='name')" -- $curr_arg ) );
 }
 
 complete -F _kube_contexts kubectx

--- a/completion/kubectx.zsh
+++ b/completion/kubectx.zsh
@@ -6,7 +6,7 @@ if [ -f "$KUBECTX" ]; then
     # show '-' only if there's a saved previous context
     PREV=$(cat "${KUBECTX}")
     _arguments "1: :((-\:Back\ to\ ${PREV} \
-        $(kubectl config get-contexts | awk '{print $2}' | tail -n +2)))"
+        $(kubectl config get-contexts --output='name')))"
 else
-    _arguments "1: :($(kubectl config get-contexts | awk '{print $2}' | tail -n +2))"
+    _arguments "1: :($(kubectl config get-contexts --output='name'))"
 fi

--- a/kubectx
+++ b/kubectx
@@ -40,8 +40,7 @@ current_context() {
 }
 
 get_contexts() {
-  kubectl config view \
-    -o=jsonpath='{range .contexts[*].name}{@}{"\n"}{end}'
+  kubectl config get-contexts --output=name
 }
 
 list_contexts() {


### PR DESCRIPTION
Hi,

I found the bash completion script didn't correctly identify the available contexts.

Here's the contexts defined in my ~/.kube/config
```
▶ kubectl config get-contexts
CURRENT   NAME                  CLUSTER         AUTHINFO          NAMESPACE
          kafka                 k8s-test        admin-test        kafka-cluster
          minikube              minikube        minikube
          k8s-blue-1-admin      k8s-blue-1      admin-blue-1      default
          k8s-bowmank-admin     k8s-bowmank     admin-bowmank     default
          k8s-test-admin        k8s-test        admin-test        default
*         k8s-westcotts-admin   k8s-westcotts   admin-westcotts   default
```

Contexts reported by kubectx 0.2,
```
▶ kubectl config get-contexts | awk '{print $2}' | tail -n +2
k8s-blue-1
k8s-bowmank
k8s-test
k8s-westcotts-admin
k8s-test
minikube
```

After this patch,
```
▶ kubectl config get-contexts --output='name'
k8s-test-admin
k8s-westcotts-admin
kafka
minikube
k8s-blue-1-admin
k8s-bowmank-admin
```