### PR TITLE
Add --with-short-names option

### DIFF
--- a/Formula/kubectx.rb
+++ b/Formula/kubectx.rb
@@ -3,15 +3,16 @@ class Kubectx < Formula
   homepage "https://github.com/ahmetb/kubectx"
   url "https://github.com/ahmetb/kubectx/archive/v0.2.0.tar.gz"
   sha256 "28069aff84aaba1aa38f42d3b27e64e460a5c0651fb56b1748f44fd832d912e3"
-  head "https://github.com/ahmetb/kubectx.git", :branch => "master"
-
-
+  head "https://github.com/ahmetb/kubectx.git", :branch => "short-names"
   bottle :unneeded
 
+  option "with-short-names", "link as \"kctx\" and \"kns\" instead"
+
   def install
-    bin.install "kubectx"
-    bin.install "kubens"
+    bin.install "kubectx" => build.with?("short-names") ? "kctx" : "kubectx"
+    bin.install "kubens" => build.with?("short-names") ? "kns" : "kubens"
     include.install "utils.bash"
+
     bash_completion.install "completion/kubectx.bash" => "kubectx"
     bash_completion.install "completion/kubens.bash" => "kubens"
     zsh_completion.install "completion/kubectx.zsh" => "_kubectx"
@@ -19,7 +20,7 @@ class Kubectx < Formula
   end
 
   test do
-    system "which", "kubectx"
-    system "which", "kubens"
+    system "which", build.with?("short-names") ? "kctx" : "kubectx"
+    system "which", build.with?("short-names") ? "kns" : "kubens"
   end
 end

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ names.
 
 ## Installation
 
-For macOS:
+**For macOS:**
 
 > Use [Homebrew](https://brew.sh/) package manager:
 >
@@ -80,7 +80,10 @@ For macOS:
 >      brew install kubectx
 > this will also set up bash/zsh completion scripts automatically.
 
-Other platforms:
+Running `brew install` with `--with-short-names` will install tools with names
+`kctx` and `kns` to prevent prefix collision with `kubectl` name.
+
+**Other platforms:**
 
 > Download the `kubectx` script, make it executable and add it to your PATH. You
 > can also install bash/zsh [completion scripts](completion/) manually.

--- a/completion/kubectx.bash
+++ b/completion/kubectx.bash
@@ -5,4 +5,4 @@ _kube_contexts()
   COMPREPLY=( $(compgen -W "- $(kubectl config get-contexts --output='name')" -- $curr_arg ) );
 }
 
-complete -F _kube_contexts kubectx
+complete -F _kube_contexts kubectx kctx

--- a/completion/kubectx.zsh
+++ b/completion/kubectx.zsh
@@ -1,10 +1,10 @@
-#compdef kubectx
+#compdef kubectx kctx=kubectx
 
-KUBECTX="${HOME}/.kube/kubectx"
+local KUBECTX="${HOME}/.kube/kubectx"
 PREV=""
 if [ -f "$KUBECTX" ]; then
     # show '-' only if there's a saved previous context
-    PREV=$(cat "${KUBECTX}")
+    local PREV=$(cat "${KUBECTX}")
     _arguments "1: :((-\:Back\ to\ ${PREV} \
         $(kubectl config get-contexts --output='name')))"
 else

--- a/completion/kubens.bash
+++ b/completion/kubens.bash
@@ -5,4 +5,4 @@ _kube_namespaces()
   COMPREPLY=( $(compgen -W "- $(kubectl get namespaces -o=jsonpath='{range .items[*].metadata.name}{@}{"\n"}{end}')" -- $curr_arg ) );
 }
 
-complete -F _kube_namespaces kubens
+complete -F _kube_namespaces kubens kns

--- a/completion/kubens.zsh
+++ b/completion/kubens.zsh
@@ -1,2 +1,2 @@
-#compdef kubens
+#compdef kubens kns=kubens
 _arguments "1: :(- $(kubectl get namespaces -o=jsonpath='{range .items[*].metadata.name}{@}{"\n"}{end}'))"


### PR DESCRIPTION
This allows linking as "kctx" and "kns" to prevent overlap with kubectl Tab
completion when user hits ku<kbd>Tab</kbd>. Fixes #3.

Also fixed variables `KUBECTX` and `PREV` leaking to zsh shell once the `_kubectx`
function is invoked.
