### PR TITLE
Fallback to readlink -f on macOS

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -21,7 +21,9 @@
 set -eou pipefail
 IFS=$'\n\t'
 
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+SCRIPT_DIR="$(dirname "$( readlink -f "${0}" 2>/dev/null || \
+  python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "${0}" )")"
+
 if [[ -f "${SCRIPT_DIR}/utils.bash" ]]; then
   source "${SCRIPT_DIR}/utils.bash"
 else

--- a/kubens
+++ b/kubens
@@ -21,7 +21,9 @@
 set -eou pipefail
 IFS=$'\n\t'
 
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+SCRIPT_DIR="$(dirname "$( readlink -f "${0}" 2>/dev/null || \
+  python -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "${0}" )")"
+
 if [[ -f "${SCRIPT_DIR}/utils.bash" ]]; then
   source "${SCRIPT_DIR}/utils.bash"
 else


### PR DESCRIPTION
BSD coreutils readlink doesn't have -f option, so
adding a Python one-liner feedback to eval symlinks/homedir.
Fixes #8.

