### PR TITLE
Don't use color in output if piping is used

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -38,7 +38,6 @@ USAGE:
   kubectx                   : list the contexts
   kubectx <NAME>            : switch to context <NAME>
   kubectx -                 : switch to the previous context
-  kubectx -p,--pipe         : disable colors, usefull when piping commands 
   kubectx <NEW_NAME>=<NAME> : rename context <NAME> to <NEW_NAME>
   kubectx -h,--help         : show this message
 EOF

--- a/kubectx
+++ b/kubectx
@@ -38,6 +38,7 @@ USAGE:
   kubectx                   : list the contexts
   kubectx <NAME>            : switch to context <NAME>
   kubectx -                 : switch to the previous context
+  kubectx -p,--pipe         : disable colors, usefull when piping commands 
   kubectx <NEW_NAME>=<NAME> : rename context <NAME> to <NEW_NAME>
   kubectx -h,--help         : show this message
 EOF
@@ -53,7 +54,11 @@ list_contexts() {
 
   for c in $(get_contexts); do
   if [[ "${c}" = "${cur}" ]]; then
-    echo "${darkbg}${yellow}${c}${normal}"
+    if [[ -t 1 ]]; then
+      echo "${darkbg}${yellow}${c}${normal}"
+    else
+      echo "${c}"
+    fi
   else
     echo "${c}"
   fi


### PR DESCRIPTION
Suggest code change that will enable use-cases like this:
`for env in $(kubectx | grep staging); do kubectx $env && kubectl scale deployments nginx --replicas=10; done`