### PR TITLE
Add Fish Shell Completions

### DIFF
--- a/completion/kubectx.fish
+++ b/completion/kubectx.fish
@@ -1,0 +1,3 @@
+# kubectx
+complete -f -c kubectx -a "- (kubectl config get-contexts --output='name')"
+

--- a/completion/kubens.fish
+++ b/completion/kubens.fish
@@ -1,0 +1,3 @@
+# kubens
+complete -f -c kubens -a "(kubectl get ns -o=custom-columns=NAME:.metadata.name --no-headers)"
+


### PR DESCRIPTION
Add fish shell completions. 

Note: in order to install this completions via `brew install`, [kubectx.rb](https://github.com/Homebrew/homebrew-core/blob/master/Formula/kubectx.rb) brew formula needs to be updated to include:

```
    fish_completion.install "completion/kubectx.fish" => "_kubectx"
    fish_completion.install "completion/kubens.fish" => "_kubens"
```