### PR TITLE
Only print colours when connected to a terminal

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -47,9 +47,13 @@ EOF
 list_contexts() {
   set -u pipefail
   local cur="$(current_context)"
-  local yellow=$(tput setaf 3)
-  local darkbg=$(tput setab 0)
-  local normal=$(tput sgr0)
+
+  local yellow darkbg normal
+  if [[ -t 1 ]]; then
+    yellow=$(tput setaf 3)
+    darkbg=$(tput setab 0)
+    normal=$(tput sgr0)
+  fi
 
   for c in $(get_contexts); do
   if [[ "${c}" = "${cur}" ]]; then

--- a/kubens
+++ b/kubens
@@ -98,9 +98,12 @@ set_namespace() {
 list_namespaces() {
   local cur="$(current_namespace)"
 
-  local yellow=$(tput setaf 3)
-  local darkbg=$(tput setab 0)
-  local normal=$(tput sgr0)
+  local yellow darkbg normal
+  if [[ -t 1 ]]; then
+    yellow=$(tput setaf 3)
+    darkbg=$(tput setab 0)
+    normal=$(tput sgr0)
+  fi
 
   for c in $(get_namespaces); do
     if [[ "${c}" = "${cur}" ]]; then


### PR DESCRIPTION
This is useful when using `kubectx` or `kubens` as part of a pipeline or when redirecting to a file and outputting colours' escape sequences is undesirable, i.e.
```
$ kubectx | less
$ kubens | grep "<ctx>"
$ kubectx > contexts.txt
$ kubens > namespaces.txt
```
