### PR TITLE
Do not print colors if stdout isn't tty

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -59,7 +59,7 @@ list_contexts() {
   normal=$(tput sgr0)
 
   for c in $(get_contexts); do
-  if [[ "${c}" = "${cur}" ]]; then
+  if [[ -t 1 && "${c}" = "${cur}" ]]; then
     echo "${darkbg}${yellow}${c}${normal}"
   else
     echo "${c}"

--- a/kubens
+++ b/kubens
@@ -113,7 +113,7 @@ list_namespaces() {
   cur="$(current_namespace)"
   ns_list=$(get_namespaces)
   for c in $ns_list; do
-    if [[ "${c}" = "${cur}" ]]; then
+    if [[ -t 1 && "${c}" = "${cur}" ]]; then
       echo "${darkbg}${yellow}${c}${normal}"
     else
       echo "${c}"


### PR DESCRIPTION
This is previously offered in #18, #22, and #27 and I previously rejected
these PRs. My rationale was to prevent scripting around kubectx as it is
meant to be used as an interactive tool.

But clearly that will be a problem, when you're doing operations like:

    kubectx -d $(kubectx)

which I proposed in #39. Plus this change is harmless. I think this
implementation does a better check than the previous ones.