### PR TITLE
Make the scripts portable

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # kubectx(1) is a utility to manage and switch between kubectl contexts.
 

--- a/kubens
+++ b/kubens
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # kubenx(1) is a utility to switch between Kubernetes namespaces.
 


### PR DESCRIPTION
Some unix like systems (including some linux distributions) put the bash interpreter in other locations than `/bin`. By using `env` the scripts work on those as well.