### PR TITLE
Use * to indicate current context & current namespace

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -60,7 +60,7 @@ list_contexts() {
 
   for c in $(get_contexts); do
   if [[ -t 1 && "${c}" = "${cur}" ]]; then
-    echo "${darkbg}${yellow}${c}${normal}"
+    echo "* ${darkbg}${yellow}${c}${normal}"
   else
     echo "${c}"
   fi

--- a/kubens
+++ b/kubens
@@ -114,7 +114,7 @@ list_namespaces() {
   ns_list=$(get_namespaces)
   for c in $ns_list; do
     if [[ -t 1 && "${c}" = "${cur}" ]]; then
-      echo "${darkbg}${yellow}${c}${normal}"
+      echo "* ${darkbg}${yellow}${c}${normal}"
     else
       echo "${c}"
     fi


### PR DESCRIPTION
For the people using [Flux](https://justgetflux.com/), It is difficult to identify the current context and current namespace which is highlighted in yellow colour.

Hence, to make it clear, added an asterisk(*) to indicate the same.