### PR TITLE
Add command attribute to show current context

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ USAGE:
   kubens                    : list the namespaces
   kubens <NAME>             : change the active namespace
   kubens -                  : switch to the previous namespace
+  kubens -c,--current       : show the current namespace
 ```
 
 

--- a/kubens
+++ b/kubens
@@ -29,6 +29,7 @@ USAGE:
   kubens                    : list the namespaces in the current context
   kubens <NAME>             : change the active namespace of current context
   kubens -                  : switch to the previous namespace in this context
+  kubens -c,--current       : show the current namespace
   kubens -h,--help          : show this message
 EOF
   exit 1
@@ -140,6 +141,8 @@ main() {
       usage
     elif [[ "${1}" == "-" ]]; then
       swap_namespace
+    elif [[ "${1}" == '-c' || "${1}" == '--current' ]]; then
+      current_namespace
     elif [[ "${1}" =~ ^-(.*) ]]; then
       echo "error: unrecognized flag \"${1}\"" >&2
       usage


### PR DESCRIPTION
Currently kubens display current namespace in the color formatted way in the namespace list, which is difficult to grep and find the current namespace.

the separate attribute to display current namespace can be helpful in finding it and then it can be easily utilized for tmux status or zsh prompt. 