### PR TITLE
Ability to switch cluster based on ordinal

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -62,12 +62,14 @@ list_contexts() {
   cur_ctx_fg=${KUBECTX_CURRENT_FGCOLOR:-$yellow}
   cur_ctx_bg=${KUBECTX_CURRENT_BGCOLOR:-$darkbg}
 
+  var="0"
   for c in $(get_contexts); do
-  if [[ -t 1 && -z "${NO_COLOR:-}" && "${c}" = "${cur}" ]]; then
-    echo "${cur_ctx_bg}${cur_ctx_fg}${c}${normal}"
-  else
-    echo "${c}"
-  fi
+    if [[ -t 1 && -z "${NO_COLOR:-}" && "${c}" == "${cur}" ]]; then
+      echo "${var}: ${cur_ctx_bg}${cur_ctx_fg}${c}${normal}"
+    else
+      echo "${var}: ${c}"
+    fi
+    var=$((var + 1))
   done
 }
 
@@ -82,7 +84,7 @@ save_context() {
   saved="$(read_context)"
 
   if [[ "${saved}" != "${1}" ]]; then
-    printf %s "${1}" > "${KUBECTX}"
+    printf %s "${1}" >"${KUBECTX}"
   fi
 }
 
@@ -94,10 +96,20 @@ set_context() {
   local prev
   prev="$(current_context)"
 
-  switch_context "${1}"
-
-  if [[ "${prev}" != "${1}" ]]; then
-    save_context "${prev}"
+  re='^[0-9]+$'
+  if ! [[ "${1}" =~ $re ]]; then
+    switch_context "${1}"
+    if [[ "${prev}" != "${1}" ]]; then
+      save_context "${prev}"
+    fi
+  else
+    var=0
+    for c in $(get_contexts); do
+      if [ "$var" == "${1}" ]; then
+        switch_context "$c"
+      fi
+      var=$((var + 1))
+    done
   fi
 }
 
@@ -140,7 +152,7 @@ rename_context() {
   old_user="$(user_of_context "${old_name}")"
   old_cluster="$(cluster_of_context "${old_name}")"
   if [[ -z "$old_user" || -z "$old_cluster" ]]; then
-    echo "error: Cannot retrieve context ${old_name}."  >&2
+    echo "error: Cannot retrieve context ${old_name}." >&2
     exit 1
   fi
 
@@ -153,7 +165,7 @@ rename_context() {
 }
 
 delete_contexts() {
-  IFS=' ' read -ra CTXS <<< "${1}"
+  IFS=' ' read -ra CTXS <<<"${1}"
   for i in "${CTXS[@]}"; do
     delete_context "${i}"
   done


### PR DESCRIPTION
**Why?**

As a kubernetes admin with many clusters within GKE the copy/paste to jump about becomes quite slowing.

For example:
```
gke_beamery-global_us-east4-a_beamery-elk
gke_beamery-global_us-east4-a_beamery-secrets
gke_beamery-pre-production_us-central1-a_beamery-foundation
gke_beamery-pre-production_us-central1-a_beamery-preproduction
gke_beamery-pre-production_us-central1-a_beamery-services
gke_beamery-preview_us-central1-a_beamery-foundation
gke_beamery-preview_us-central1-a_beamery-ingestion
gke_beamery-preview_us-central1-a_beamery-preview-cluster
gke_beamery-preview_us-central1-a_beamery-services
gke_beamery-preview_us-central1-a_build
gke_beamery-production_us-east4-a_beamery-foundation
gke_beamery-production_us-east4-a_beamery-production
gke_beamery-production_us-east4-a_beamery-service-cluster
minikube
```

When not jumping forward or backward, it involves a copy paste command every selection.

**Proposal**

Addition of an ordinal in the list context to then allow set_context with the ordinal.

Example:

```
0: gke_beamery-global_us-east4-a_beamery-elk
1: gke_beamery-global_us-east4-a_beamery-secrets
2: gke_beamery-pre-production_us-central1-a_beamery-foundation
3: gke_beamery-pre-production_us-central1-a_beamery-preproduction
4: gke_beamery-pre-production_us-central1-a_beamery-services
5: gke_beamery-preview_us-central1-a_beamery-foundation
6: gke_beamery-preview_us-central1-a_beamery-ingestion
7: gke_beamery-preview_us-central1-a_beamery-preview-cluster
8: gke_beamery-preview_us-central1-a_beamery-services
9: gke_beamery-preview_us-central1-a_build
10: gke_beamery-production_us-east4-a_beamery-foundation
11: gke_beamery-production_us-east4-a_beamery-production
12: gke_beamery-production_us-east4-a_beamery-service-cluster
13: minikube
```

```
kubectx 2 
Switched to context "gke_beamery-pre-production_us-central1-a_beamery-foundation".
```


CLA has been signed. 

Thanks