### PR TITLE
ignore errors from tput (to fix TERM=vt100)

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -53,9 +53,9 @@ list_contexts() {
   cur="$(current_context)"
 
   local yellow darkbg normal
-  yellow=$(tput setaf 3)
-  darkbg=$(tput setab 0)
-  normal=$(tput sgr0)
+  yellow=$(tput setaf 3 || true)
+  darkbg=$(tput setab 0 || true)
+  normal=$(tput sgr0 || true)
 
   local cur_ctx_fg cur_ctx_bg
   cur_ctx_fg=${KUBECTX_CURRENT_FGCOLOR:-$yellow}

--- a/kubens
+++ b/kubens
@@ -104,9 +104,9 @@ set_namespace() {
 
 list_namespaces() {
   local yellow darkbg normal
-  yellow=$(tput setaf 3)
-  darkbg=$(tput setab 0)
-  normal=$(tput sgr0)
+  yellow=$(tput setaf 3 || true)
+  darkbg=$(tput setab 0 || true)
+  normal=$(tput sgr0 || true)
 
   local cur_ctx_fg cur_ctx_bg
   cur_ctx_fg=${KUBECTX_CURRENT_FGCOLOR:-$yellow}


### PR DESCRIPTION
    Currently TERM=vt100 is causing kubectx failure since tput is returning
    exitcode=1. vt100 does not have colors. Ignoring tput exit code.

Fixes #57.