### PR TITLE
README: Install completion for zsh & Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ them to any POSIX environment that has Bash installed.
 - Figure out how to install bash/zsh/fish [completion scripts](completion/).  
   - For zsh:
    ```bash
-   sudo ln kubectx/completion/kubectx.zsh /usr/share/zsh/functions/Completion/Zsh/_kubectx.zsh
-   sudo ln kubectx/completion/kubens.zsh /usr/share/zsh/functions/Completion/Zsh/_kubens.zsh`
+   sudo ln -s kubectx/completion/kubectx.zsh /usr/share/zsh/functions/Completion/Zsh/_kubectx.zsh
+   sudo ln -s kubectx/completion/kubens.zsh /usr/share/zsh/functions/Completion/Zsh/_kubens.zsh`
    ```
 
 Example installation steps:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,12 @@ them to any POSIX environment that has Bash installed.
   - or save them to a directory, then create symlinks to `kubectx`/`kubens` from
     somewhere in your `PATH`, like `/usr/local/bin`
 - Make `kubectx` and `kubens` executable (`chmod +x ...`)
-- Figure out how to install bash/zsh/fish [completion scripts](completion/).
+- Figure out how to install bash/zsh/fish [completion scripts](completion/).  
+  - For zsh:
+   ```bash
+   sudo ln kubectx/completion/kubectx.zsh /usr/share/zsh/functions/Completion/Zsh/_kubectx.zsh
+   sudo ln kubectx/completion/kubens.zsh /usr/share/zsh/functions/Completion/Zsh/_kubens.zsh`
+   ```
 
 Example installation steps:
 

--- a/README.md
+++ b/README.md
@@ -101,13 +101,21 @@ them to any POSIX environment that has Bash installed.
   - or save them to a directory, then create symlinks to `kubectx`/`kubens` from
     somewhere in your `PATH`, like `/usr/local/bin`
 - Make `kubectx` and `kubens` executable (`chmod +x ...`)
-- Figure out how to install bash/zsh/fish [completion scripts](completion/).  
-  - For zsh:
-   ```bash
-   sudo ln -s kubectx/completion/kubectx.zsh /usr/share/zsh/functions/Completion/Zsh/_kubectx.zsh
-   sudo ln -s kubectx/completion/kubens.zsh /usr/share/zsh/functions/Completion/Zsh/_kubens.zsh`
-   ```
-
+- Install bash/zsh/fish [completion scripts](completion/).  
+  - For zsh:  
+    The completion scripts have to be in a path that belongs to `$fpath`. Either link or copy them to an existing folder.  
+    If using oh-my-zsh you can do as follows:
+    ```bash
+    mkdir -p ~/.oh-my-zsh/completions
+    chmod -R 755 ~/.oh-my-zsh/completions
+    ln -s /opt/kubectx/completion/kubens.zsh ~/.oh-my-zsh/completions/_kubens.zsh
+    ln -s /opt/kubectx/completion/kubens.zsh ~/.oh-my-zsh/completions/_kubectx.zsh
+    ```  
+    Note that the leading underscore seems to be a convention.  
+    If not using oh-my-zsh, you could link to `/usr/share/zsh/functions/Completion` (might require sudo), depending on the `$fpath` of your zsh installation.  
+    In case of error, calling `compaudit` might help.
+  - For bash/fish: Figure out how to install completion scripts and please document here
+  
 Example installation steps:
 
 ``` bash


### PR DESCRIPTION
It's not exactly intuitive to use the code completion in zsh on Linux, so I added some hints to get started to the readme.