### PR TITLE
Adding dependency checker for kubectx and kubens

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -159,6 +159,10 @@ delete_context() {
 }
 
 main() {
+  if ! hash kubectl 2>/dev/null; then
+   echo >&2 "kubectl is not installed"
+   exit 1
+  fi
   if [[ "$#" -eq 0 ]]; then
     if [[ -t 1 &&  -z "${KUBECTX_IGNORE_FZF:-}" && "$(type fzf &>/dev/null; echo $?)" -eq 0 ]]; then
       choose_context_interactive

--- a/kubens
+++ b/kubens
@@ -156,6 +156,10 @@ swap_namespace() {
 }
 
 main() {
+  if ! hash kubectl 2>/dev/null; then
+   echo >&2 "kubectl is not installed"
+   exit 1
+  fi
   if [[ "$#" -eq 0 ]]; then
     if [[ -t 1 && -z ${KUBECTX_IGNORE_FZF:-} && "$(type fzf &>/dev/null; echo $?)" -eq 0 ]]; then
       choose_namespace_interactive


### PR DESCRIPTION
## Overview
~To address #5~ Misunderstood the issue here

~Rather than fail after attempting to get a `context` or `namespace`~ Im proposing to fail when `kubectl` is not found in the `PATH`.

Let me know what you think!

## Testing
```
$ brew unlink kubectl
$ ./kubectx; echo $?
kubectl not installed
1
$ ./kubens; echo $? 
kubectl not installed
1
```

> Also submitted the CLA as described in CONTRIBUTING.md