### PR TITLE
Support XDG_CACHE_HOME environment variable

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -22,7 +22,7 @@ set -eou pipefail
 IFS=$'\n\t'
 
 SELF_CMD="$0"
-KUBECTX="${HOME}/.kube/kubectx"
+KUBECTX="${XDG_CACHE_HOME:-$HOME/.kube}/kubectx"
 
 usage() {
   cat <<"EOF"

--- a/kubens
+++ b/kubens
@@ -22,7 +22,7 @@ set -eou pipefail
 IFS=$'\n\t'
 
 SELF_CMD="$0"
-KUBENS_DIR="${HOME}/.kube/kubens"
+KUBENS_DIR="${XDG_CACHE_HOME:-$HOME/.kube}/kubens"
 
 usage() {
   cat <<"EOF"


### PR DESCRIPTION
By using the `XDG_CACHE_HOME` environment variable, people who set kubectl's config file elsewhere (using the `KUBECONFIG` environment variable) could now bypass the error that `~/.kube` directory doesn't exist, and also support the XDG standard :)