### PR TITLE
[REVIEW] Proposal to fix subshell error handling

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -40,6 +40,11 @@ USAGE:
 EOF
 }
 
+exit_err() {
+   echo >&2 "${1}"
+   exit 1
+}
+
 current_context() {
   kubectl config view -o=jsonpath='{.current-context}'
 }
@@ -50,8 +55,9 @@ get_contexts() {
 
 list_contexts() {
   set -u pipefail
-  local cur
-  cur="$(current_context)"
+  local cur ctx_list
+  cur="$(current_context)" || exit_err "error getting current context"
+  ctx_list=$(get_contexts) || exit_err "error getting context list"
 
   local yellow darkbg normal
   yellow=$(tput setaf 3 || true)
@@ -62,7 +68,7 @@ list_contexts() {
   cur_ctx_fg=${KUBECTX_CURRENT_FGCOLOR:-$yellow}
   cur_ctx_bg=${KUBECTX_CURRENT_BGCOLOR:-$darkbg}
 
-  for c in $(get_contexts); do
+  for c in $ctx_list; do
   if [[ -t 1 && -z "${NO_COLOR:-}" && "${c}" = "${cur}" ]]; then
     echo "${cur_ctx_bg}${cur_ctx_fg}${c}${normal}"
   else
@@ -103,7 +109,7 @@ choose_context_interactive() {
 
 set_context() {
   local prev
-  prev="$(current_context)"
+  prev="$(current_context)" || exit_err "error getting current context"
 
   switch_context "${1}"
 
@@ -152,7 +158,7 @@ delete_context() {
   local ctx
   ctx="${1}"
   if [[ "${ctx}" == "." ]]; then
-    ctx="$(current_context)"
+    ctx="$(current_context)" || exit_err "error getting current context"
   fi
   echo "Deleting context \"${ctx}\"..." >&2
   kubectl config delete-context "${ctx}"

--- a/kubens
+++ b/kubens
@@ -34,10 +34,16 @@ USAGE:
 EOF
 }
 
+exit_err() {
+   echo >&2 "${1}"
+   exit 1
+}
+
 current_namespace() {
   local cur_ctx
-  cur_ctx="$(current_context)"
-  ns="$(kubectl config view -o=jsonpath="{.contexts[?(@.name==\"${cur_ctx}\")].context.namespace}")"
+  cur_ctx="$(current_context)" || exit_err "error getting current context"
+  ns="$(kubectl config view -o=jsonpath="{.contexts[?(@.name==\"${cur_ctx}\")].context.namespace}")" \
+     || exit_err "error getting current namespace"
   if [[ -z "${ns}" ]]; then
     echo "default"
   else
@@ -107,8 +113,8 @@ choose_namespace_interactive() {
 
 set_namespace() {
   local ctx prev
-  ctx="$(current_context)"
-  prev="$(current_namespace)"
+  ctx="$(current_context)" || exit_err "error getting current context"
+  prev="$(current_namespace)" || exit_error "error getting current namespace"
 
   if grep -q ^"${1}"\$ <(get_namespaces); then
     switch_namespace "${ctx}" "${1}"
@@ -133,8 +139,9 @@ list_namespaces() {
   cur_ctx_bg=${KUBECTX_CURRENT_BGCOLOR:-$darkbg}
 
   local cur ns_list
-  cur="$(current_namespace)"
-  ns_list=$(get_namespaces)
+  cur="$(current_namespace)" || exit_err "error getting current namespace"
+  ns_list=$(get_namespaces) || exit_err "error getting namespace list"
+
   for c in $ns_list; do
     if [[ -t 1 && -z "${NO_COLOR:-}" && "${c}" = "${cur}" ]]; then
       echo "${cur_ctx_bg}${cur_ctx_fg}${c}${normal}"
@@ -146,7 +153,7 @@ list_namespaces() {
 
 swap_namespace() {
   local ctx ns
-  ctx="$(current_context)"
+  ctx="$(current_context)" || exit_err "error getting current context"
   ns="$(read_namespace "${ctx}")"
   if [[ -z "${ns}" ]]; then
     echo "error: No previous namespace found for current context." >&2


### PR DESCRIPTION
# Overview
Proposal to address #5 

My proposal is to check the `return code` of the problematic functions. If any of them return a non-zero, call `exit_err` immediately, print an error message to `stderror` and `exit 1`.

# Testing
Validate that `kubectx` and `kubens` still function. I wasnt able to force `kubectx` and/or `kubens` to fail in the middle of gathering contexts or namespaces so I used this test function to test my concepts:

```bash
#!/usr/bin/env bash
set -o pipefail

exit_err() {    
   echo >&2 "${1}"        
   exit 1                    
} 

get_contexts() {
  echo -e "hello\nyay\nworld"
}

# Supposed to fail
get_contexts_fail() {
  echo -e "hello\nyay\nworld"
  tar -clv | sort -n
}

# Will Succeed 
cons=$(get_contexts) || exit_err "error on test 1"
for con in $cons; do
  echo $con
done

echo "finished get context"

# Will Fail
cons=$(get_contexts_fail) || exit_err "error on test 2"
for con in $cons; do
  echo $con
done
```

Running it to simulate how an error would return from a function like `get_contexts` in `kubectx`:

```bash
~$ bash test.sh
hello
yay
world
finished get context
tar: Cowardly refusing to create an empty archive
Try 'tar --help' or 'tar --usage' for more information.
error on test 2
```

@ahmetb if youve got any ideas for ways to simulate a failure during `get_context` or similar functions calling `kubectl` let me know. Hopefully this is more of what you're looking for to solve for the subshell issue.