### PR TITLE
 Add feature and flag to print current context / namespace

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -30,13 +30,14 @@ USAGE:
   kubectx                       : list the contexts
   kubectx <NAME>                : switch to context <NAME>
   kubectx -                     : switch to the previous context
+  kubectx -c,--current          : print the current context
   kubectx <NEW_NAME>=<NAME>     : rename context <NAME> to <NEW_NAME>
   kubectx <NEW_NAME>=.          : rename current-context to <NEW_NAME>
   kubectx -d <NAME> [<NAME...>] : delete context <NAME> ('.' for current-context)
                                   (this command won't delete the user/cluster entry
                                   that is used by the context)
 
-  kubectx -h,--help         : show this message
+  kubectx -h,--help             : show this message
 EOF
 }
 
@@ -194,6 +195,8 @@ main() {
   elif [[ "$#" -eq 1 ]]; then
     if [[ "${1}" == "-" ]]; then
       swap_context
+    elif [[ "${1}" == '-c' || "${1}" == '--current' ]]; then
+      echo -e "$(current_context)"
     elif [[ "${1}" == '-h' || "${1}" == '--help' ]]; then
       usage
     elif [[ "${1}" =~ ^-(.*) ]]; then

--- a/kubens
+++ b/kubens
@@ -30,6 +30,7 @@ USAGE:
   kubens                    : list the namespaces in the current context
   kubens <NAME>             : change the active namespace of current context
   kubens -                  : switch to the previous namespace in this context
+  kubens -c,--current       : print the current namespace
   kubens -h,--help          : show this message
 EOF
 }
@@ -183,6 +184,8 @@ main() {
   elif [[ "$#" -eq 1 ]]; then
     if [[ "${1}" == '-h' || "${1}" == '--help' ]]; then
       usage
+    elif [[ "${1}" == '-c' || "${1}" == '--current' ]]; then
+      echo -e "$(current_namespace)"
     elif [[ "${1}" == "-" ]]; then
       swap_namespace
     elif [[ "${1}" =~ ^-(.*) ]]; then


### PR DESCRIPTION
Sometimes we forget what the current context / namespace is and would like an easy way to just print it in the console. So I've added this simple feature to this great script. Furthermore, we use it to create a full listing of the current context / namespace / pods, etc.