### PR TITLE
implement "-c NAME NEW_NAME" for copying contexts

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -35,6 +35,8 @@ USAGE:
   kubectx -d <NAME> [<NAME...>] : delete context <NAME> ('.' for current-context)
                                   (this command won't delete the user/cluster entry
                                   that is used by the context)
+  kubectx -c <NAME> <NEW_NAME>  : copy context <NAME> ('.' for current-context)
+                                  to <NEW_NAME>
 
   kubectx -h,--help         : show this message
 EOF
@@ -148,6 +150,25 @@ rename_context() {
   $KUBECTL config rename-context "${old_name}" "${new_name}"
 }
 
+copy_context() {
+  local old_name="${1}"
+  local new_name="${2}"
+  local cluster authinfo namespace
+
+  if [[ "${old_name}" == "." ]]; then
+    old_name="$(current_context)"
+  fi
+
+  if context_exists "${new_name}"; then
+    echo "Context \"${new_name}\" exists, deleting..." >&2
+    $KUBECTL config delete-context "${new_name}" 1>/dev/null 2>&1
+  fi
+
+  IFS=' ' read -r  _ cluster authinfo namespace <<<"$($KUBECTL config get-contexts "$old_name" | tail -n1 | sed -e 's/^\*//')"
+  echo "Copying context \"${old_name}\" to \"${new_name}\""
+  $KUBECTL config set-context "$new_name" --cluster="$cluster" --user="$authinfo" --namespace="$namespace"
+}
+
 delete_contexts() {
   for i in "${@}"; do
     delete_context "${i}"
@@ -187,6 +208,13 @@ main() {
       exit 1
     fi
     delete_contexts "${@:2}"
+  elif [[ "${1}" == "-c" ]]; then
+    if [[ "$#" -lt 2 ]]; then
+      echo "error: missing context NAME or NEW_NAME" >&2
+      usage
+      exit 1
+    fi
+    copy_context "${@:2}"
   elif [[ "$#" -gt 1 ]]; then
     echo "error: too many arguments" >&2
     usage


### PR DESCRIPTION
This PR implements functionality to allow copying contexts. My use case for this is primarily for making it easier for folks to work with GKE clusters while still having the canonical GKE context name available.

For example, an engineering team may have a gke cluster named `gke_my-project_us-central1_cluster-01`. And this engineering team may have common tooling that expects a context of that name to be available. Also, engineers on this team want to be able to address this cluster as simply `cluster-01`. With the ability to copy a context to a new name the engineers on this team can make a friendly short name and not risk breaking any common tooling that expects the longer, default context name provided by GKE.