### PR TITLE
Show visual indication of the selected namespace and context

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,13 @@ them to any POSIX environment that has Bash installed.
     export PATH=~/.kubectx:\$PATH
     FOE
     ```
-  - For fish: Figure out how to install completion scripts and please document here
-  
+  - For fish:
+    ```fish
+    mkdir -p ~/.config/fish/completions
+    ln -s /opt/kubectx/completion/kubectx.fish ~/.config/fish/completions/
+    ln -s /opt/kubectx/completion/kubens.fish ~/.config/fish/completions/
+    ```
+
 Example installation steps:
 
 ``` bash

--- a/kubectx
+++ b/kubectx
@@ -69,11 +69,11 @@ list_contexts() {
   cur_ctx_bg=${KUBECTX_CURRENT_BGCOLOR:-$darkbg}
 
   for c in $ctx_list; do
-  if [[ -t 1 && -z "${NO_COLOR:-}" && "${c}" = "${cur}" ]]; then
-    echo "${cur_ctx_bg}${cur_ctx_fg}${c}${normal}"
-  else
-    echo "${c}"
-  fi
+    if [[ (-t 1 || ! -z ${KUBENS_FZF:-}) && -z "${NO_COLOR:-}" && "${c}" = "${cur}" ]]; then
+      echo "${cur_ctx_bg}${cur_ctx_fg}${c}${normal}"
+    else
+      echo "${c}"
+    fi
   done
 }
 
@@ -98,7 +98,7 @@ switch_context() {
 
 choose_context_interactive() {
   local choice
-  choice="$(FZF_DEFAULT_COMMAND="${SELF_CMD}" fzf --ansi || true)"
+  choice="$(KUBENS_FZF=1 FZF_DEFAULT_COMMAND="${SELF_CMD}" fzf --ansi || true)"
   if [[ -z "${choice}" ]]; then
     echo 2>&1 "error: you did not choose any of the options"
     exit 1

--- a/kubens
+++ b/kubens
@@ -104,7 +104,7 @@ choose_namespace_interactive() {
   fi
 
   local choice
-  choice="$(FZF_DEFAULT_COMMAND="${SELF_CMD}" fzf --ansi || true)"
+  choice="$(KUBENS_FZF=1 FZF_DEFAULT_COMMAND="${SELF_CMD}" fzf --ansi || true)"
   if [[ -z "${choice}" ]]; then
     echo 2>&1 "error: you did not choose any of the options"
     exit 1
@@ -145,7 +145,7 @@ list_namespaces() {
   ns_list=$(get_namespaces) || exit_err "error getting namespace list"
 
   for c in $ns_list; do
-    if [[ -t 1 && -z "${NO_COLOR:-}" && "${c}" = "${cur}" ]]; then
+    if [[ (-t 1 || ! -z ${KUBENS_FZF:-}) && -z "${NO_COLOR:-}" && "${c}" = "${cur}" ]]; then
       echo "${cur_ctx_bg}${cur_ctx_fg}${c}${normal}"
     else
       echo "${c}"


### PR DESCRIPTION
When using `kubens` with `fzf` there's no visual indication of the selected namespace and context.
That's because `fzf` is considered a non-interactive tty, so there's no colour on the output.

This PR aims to fix that by creating a specific flag, that gets set every time we call kubens with fzf.

Fixes https://github.com/ahmetb/kubectx/issues/98 and https://github.com/ahmetb/kubectx/issues/89