### PR TITLE
Show color in interactive mode

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -69,8 +69,14 @@ list_contexts() {
   cur_ctx_bg=${KUBECTX_CURRENT_BGCOLOR:-$darkbg}
 
   for c in $ctx_list; do
-  if [[ -t 1 && -z "${NO_COLOR:-}" && "${c}" = "${cur}" ]]; then
-    echo "${cur_ctx_bg}${cur_ctx_fg}${c}${normal}"
+  if [[ -n "${_KUBECTX_FORCE_COLOR:-}" || \
+       -t 1 && -z "${NO_COLOR:-}" ]]; then
+    # colored output mode
+    if [[ "${c}" = "${cur}" ]]; then
+      echo "${cur_ctx_bg}${cur_ctx_fg}${c}${normal}"
+    else
+      echo "${c}"
+    fi
   else
     echo "${c}"
   fi
@@ -98,7 +104,9 @@ switch_context() {
 
 choose_context_interactive() {
   local choice
-  choice="$(FZF_DEFAULT_COMMAND="${SELF_CMD}" fzf --ansi || true)"
+  choice="$(_KUBECTX_FORCE_COLOR=1 \
+    FZF_DEFAULT_COMMAND="${SELF_CMD}" \
+    fzf --ansi || true)"
   if [[ -z "${choice}" ]]; then
     echo 2>&1 "error: you did not choose any of the options"
     exit 1

--- a/kubens
+++ b/kubens
@@ -104,7 +104,9 @@ choose_namespace_interactive() {
   fi
 
   local choice
-  choice="$(FZF_DEFAULT_COMMAND="${SELF_CMD}" fzf --ansi || true)"
+  choice="$(_KUBECTX_FORCE_COLOR=1 \
+    FZF_DEFAULT_COMMAND="${SELF_CMD}" \
+    fzf --ansi || true)"
   if [[ -z "${choice}" ]]; then
     echo 2>&1 "error: you did not choose any of the options"
     exit 1
@@ -145,11 +147,17 @@ list_namespaces() {
   ns_list=$(get_namespaces) || exit_err "error getting namespace list"
 
   for c in $ns_list; do
-    if [[ -t 1 && -z "${NO_COLOR:-}" && "${c}" = "${cur}" ]]; then
+  if [[ -n "${_KUBECTX_FORCE_COLOR:-}" || \
+       -t 1 && -z "${NO_COLOR:-}" ]]; then
+    # colored output mode
+    if [[ "${c}" = "${cur}" ]]; then
       echo "${cur_ctx_bg}${cur_ctx_fg}${c}${normal}"
     else
       echo "${c}"
     fi
+  else
+    echo "${c}"
+  fi
   done
 }
 


### PR DESCRIPTION
This patch introduces an internal _KUBECTX_FORCE_COLOR environment variable
that overrides color output decision.

With this, fzf output shows the color indicators for ctx/ns and choosing the
option with the color works without any extra handling.

Fixes #89.
Fixes #98.