### PR TITLE
add kubectx and kubens as artifacts to tagged releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,12 @@ before_install:
   - sudo chmod +x /usr/bin/kubectl 
 script:
   - bats test/
+deploy:
+  provider: releases
+  api_key: "GITHUB_TOKEN" # has to be defined in Travis
+  file:
+    - "kubectx"
+    - "kubens"
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
This PR adds a `deploy` stage to `.travis.yml` which adds kubectx and kubens to a tagged release