### PR TITLE
Add ZSH framework support

### DIFF
--- a/kubectx.plugin.zsh
+++ b/kubectx.plugin.zsh
@@ -1,0 +1,7 @@
+#!/usr/bin/env zsh
+#
+# Enables this repo to be autoloaded by ZSH frameworks that support
+# oh-my-zsh format plugins.
+
+KUBECTX_DIR="$(dirname $0)"
+export PATH=${PATH}:${KUBECTX_DIR}


### PR DESCRIPTION
This file enables loading the repository as a plugin by oh-my-zsh compatible frameworks.

The big advantage to this is that frameworks like [antigen](https://github.com/zsh-users/antigen) and [zgen](https://github.com/tarjoilija/zgen) will handle automatically cloning the repository, adding the checkout's directory to the user's `$PATH`, and also will periodically `git pull` to keep them up to date without the user having to remember to do it.