### PR TITLE
Fixed fzf issue on ubuntu with kubectl query

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -21,7 +21,6 @@
 set -eou pipefail
 IFS=$'\n\t'
 
-SELF_CMD="$0"
 KUBECTX="${XDG_CACHE_HOME:-$HOME/.kube}/kubectx"
 
 usage() {
@@ -105,8 +104,8 @@ switch_context() {
 choose_context_interactive() {
   local choice
   choice="$(_KUBECTX_FORCE_COLOR=1 \
-    FZF_DEFAULT_COMMAND="${SELF_CMD}" \
-    fzf --ansi || true)"
+    $KUBECTL config get-contexts --output='name' | \
+    fzf --ansi --height 40% --reverse || true)"
   if [[ -z "${choice}" ]]; then
     echo 2>&1 "error: you did not choose any of the options"
     exit 1

--- a/kubens
+++ b/kubens
@@ -21,7 +21,6 @@
 set -eou pipefail
 IFS=$'\n\t'
 
-SELF_CMD="$0"
 KUBENS_DIR="${XDG_CACHE_HOME:-$HOME/.kube}/kubens"
 
 usage() {
@@ -105,8 +104,8 @@ choose_namespace_interactive() {
 
   local choice
   choice="$(_KUBECTX_FORCE_COLOR=1 \
-    FZF_DEFAULT_COMMAND="${SELF_CMD}" \
-    fzf --ansi || true)"
+    $KUBECTL get namespaces -o=jsonpath='{range.items[*].metadata.name}{@}{"\n"}{end}' | \
+    fzf --ansi --height 60% --reverse || true)"
   if [[ -z "${choice}" ]]; then
     echo 2>&1 "error: you did not choose any of the options"
     exit 1


### PR DESCRIPTION
I use this tool on macOS (installed via homebrew) with no issues, but when I cloned the repo on my ubuntu machine, the `$SELF_CMD` feed to `fzf` didn't work (I still haven't figured out _exactly_ why...).  The more I looked at it, the more I wondered why not just feed the results of the `kubectl` query directly to `fzf` and select from there, and when I changed it, it worked with no issues on ubuntu or macOS.

I also made a change to the `fzf` output, opting out of fullscreen mode and having it drop down from the current prompt.