### PR TITLE
Add version flag for kubectx and kubens

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -23,6 +23,7 @@ IFS=$'\n\t'
 
 SELF_CMD="$0"
 KUBECTX="${XDG_CACHE_HOME:-$HOME/.kube}/kubectx"
+KUBECTX_VERSION=""
 
 usage() {
   cat <<"EOF"
@@ -42,7 +43,7 @@ EOF
 }
 
 print_version() {
-  echo "Installed version: v0.6.3"
+  echo "Installed version: ${KUBECTX_VERSION}"
 }
 
 exit_err() {

--- a/kubectx
+++ b/kubectx
@@ -23,6 +23,8 @@ IFS=$'\n\t'
 
 SELF_CMD="$0"
 KUBECTX="${XDG_CACHE_HOME:-$HOME/.kube}/kubectx"
+
+# Do not edit. This line will be automatically updated by a git post-receive hook
 KUBECTX_VERSION="git-ed6755a95c824b729100c0b9324a4f91d61d90f3"
 
 usage() {

--- a/kubectx
+++ b/kubectx
@@ -37,7 +37,12 @@ USAGE:
                                   that is used by the context)
 
   kubectx -h,--help         : show this message
+  kubectx -v,--version      : show version and exit
 EOF
+}
+
+print_version() {
+  echo "Installed version: v0.6.3"
 }
 
 exit_err() {
@@ -202,6 +207,8 @@ main() {
   elif [[ "$#" -eq 1 ]]; then
     if [[ "${1}" == "-" ]]; then
       swap_context
+    elif [[ "${1}" == '-v' || "${1}" == '--version' ]]; then
+      print_version
     elif [[ "${1}" == '-h' || "${1}" == '--help' ]]; then
       usage
     elif [[ "${1}" =~ ^-(.*) ]]; then

--- a/kubectx
+++ b/kubectx
@@ -23,7 +23,7 @@ IFS=$'\n\t'
 
 SELF_CMD="$0"
 KUBECTX="${XDG_CACHE_HOME:-$HOME/.kube}/kubectx"
-KUBECTX_VERSION=""
+KUBECTX_VERSION="git-ed6755a95c824b729100c0b9324a4f91d61d90f3"
 
 usage() {
   cat <<"EOF"

--- a/kubens
+++ b/kubens
@@ -23,7 +23,7 @@ IFS=$'\n\t'
 
 SELF_CMD="$0"
 KUBENS_DIR="${XDG_CACHE_HOME:-$HOME/.kube}/kubens"
-KUBENS_VERSION=""
+KUBENS_VERSION="git-ed6755a95c824b729100c0b9324a4f91d61d90f3"
 
 usage() {
   cat <<"EOF"

--- a/kubens
+++ b/kubens
@@ -23,6 +23,8 @@ IFS=$'\n\t'
 
 SELF_CMD="$0"
 KUBENS_DIR="${XDG_CACHE_HOME:-$HOME/.kube}/kubens"
+
+# Do not edit. This line will be automatically updated by a git post-receive hook
 KUBENS_VERSION="git-ed6755a95c824b729100c0b9324a4f91d61d90f3"
 
 usage() {

--- a/kubens
+++ b/kubens
@@ -23,6 +23,7 @@ IFS=$'\n\t'
 
 SELF_CMD="$0"
 KUBENS_DIR="${XDG_CACHE_HOME:-$HOME/.kube}/kubens"
+KUBENS_VERSION=""
 
 usage() {
   cat <<"EOF"
@@ -37,7 +38,7 @@ EOF
 }
 
 print_version() {
-  echo "Installed version: v0.6.3"
+  echo "Installed version: ${KUBENS_VERSION}"
 }
 
 exit_err() {

--- a/kubens
+++ b/kubens
@@ -30,8 +30,14 @@ USAGE:
   kubens                    : list the namespaces in the current context
   kubens <NAME>             : change the active namespace of current context
   kubens -                  : switch to the previous namespace in this context
+
   kubens -h,--help          : show this message
+  kubens -v,--version       : show version and exit
 EOF
+}
+
+print_version() {
+  echo "Installed version: v0.6.3"
 }
 
 exit_err() {
@@ -193,6 +199,8 @@ main() {
   elif [[ "$#" -eq 1 ]]; then
     if [[ "${1}" == '-h' || "${1}" == '--help' ]]; then
       usage
+    elif [[ "${1}" == '-v' || "${1}" == '--version' ]]; then
+      print_version
     elif [[ "${1}" == "-" ]]; then
       swap_namespace
     elif [[ "${1}" =~ ^-(.*) ]]; then


### PR DESCRIPTION
When having multiple versions of kubectx installed it is currently not possible to differentiate between the versions except with looking into the code and comparing the recent changes (or checking the git tags). In my head it is convenient to have a version flag on each script. This PR adds a (_very_ basic) `--version` flag.