### PR TITLE
failed to read tty error with fzf on ubuntu 

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -106,7 +106,7 @@ choose_context_interactive() {
   local choice
   choice="$(_KUBECTX_FORCE_COLOR=1 \
     FZF_DEFAULT_COMMAND="${SELF_CMD}" \
-    fzf --ansi || true)"
+    fzf --ansi -1 || true)"
   if [[ -z "${choice}" ]]; then
     echo 2>&1 "error: you did not choose any of the options"
     exit 1


### PR DESCRIPTION
kubectx not working with fzf on ubuntu cause of ubuntu kernel bug -> https://github.com/junegunn/fzf/issues/1486

Using fzf with -1 parameter is a workaround for this bug and also give auto select if list has only one value.