### PR TITLE
Proposal: Automatically select the namespace if there is only one option after fuzzy search

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -106,7 +106,7 @@ choose_context_interactive() {
   local choice
   choice="$(_KUBECTX_FORCE_COLOR=1 \
     FZF_DEFAULT_COMMAND="${SELF_CMD}" \
-    fzf --ansi || true)"
+    fzf --ansi --query "$1" --select-1 || true)"
   if [[ -z "${choice}" ]]; then
     echo 2>&1 "error: you did not choose any of the options"
     exit 1
@@ -184,7 +184,7 @@ main() {
 
   if [[ "$#" -eq 0 ]]; then
     if [[ -t 1 &&  -z "${KUBECTX_IGNORE_FZF:-}" && "$(type fzf &>/dev/null; echo $?)" -eq 0 ]]; then
-      choose_context_interactive
+      choose_context_interactive "$*"
     else
       list_contexts
     fi
@@ -211,7 +211,11 @@ main() {
     elif [[ "${1}" =~ (.+)=(.+) ]]; then
       rename_context "${BASH_REMATCH[2]}" "${BASH_REMATCH[1]}"
     else
-      set_context "${1}"
+      if [[ -t 1 &&  -z "${KUBECTX_IGNORE_FZF:-}" && "$(type fzf &>/dev/null; echo $?)" -eq 0 ]]; then
+        choose_context_interactive "${1}"
+      else
+        set_context "$1"
+      fi
     fi
   else
     usage

--- a/kubens
+++ b/kubens
@@ -106,7 +106,7 @@ choose_namespace_interactive() {
   local choice
   choice="$(_KUBECTX_FORCE_COLOR=1 \
     FZF_DEFAULT_COMMAND="${SELF_CMD}" \
-    fzf --ansi || true)"
+    fzf --ansi --query "$1" --select-1 || true)"
   if [[ -z "${choice}" ]]; then
     echo 2>&1 "error: you did not choose any of the options"
     exit 1
@@ -186,7 +186,7 @@ main() {
 
   if [[ "$#" -eq 0 ]]; then
     if [[ -t 1 && -z ${KUBECTX_IGNORE_FZF:-} && "$(type fzf &>/dev/null; echo $?)" -eq 0 ]]; then
-      choose_namespace_interactive
+      choose_namespace_interactive "$*"
     else
       list_namespaces
     fi
@@ -202,7 +202,11 @@ main() {
     elif [[ "${1}" =~ (.+)=(.+) ]]; then
       alias_context "${BASH_REMATCH[2]}" "${BASH_REMATCH[1]}"
     else
-      set_namespace "${1}"
+      if [[ -t 1 &&  -z "${KUBECTX_IGNORE_FZF:-}" && "$(type fzf &>/dev/null; echo $?)" -eq 0 ]]; then
+        choose_namespace_interactive "${1}"
+      else
+        set_namespace "${1}"
+      fi
     fi
   else
     echo "error: too many flags" >&2


### PR DESCRIPTION
This PR will make `kubectx` and `kubens` select namespace **directly** *if there is a single result* based on fuzzy match.

**Note:** This will work only when `fzf` is enabled

**Example:**
Lets say we have three namespaces.

    $ KUBECTX_IGNORE_FZF=false kubens
    default
    kube-public
    kube-system

With this PR,

    kubens def # will change to default namespace
    kubens sys # will change to kube-sytem namespace
    kubens pub # will change to kube-public namespace
    kubens ksy # will change to kube-system namespace
    kubens kube # will take you to interactive session where we have to select between kube-public and kube-system
Similarly, it will work for `kubectx`
