### PR TITLE
improved fzf usage

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -106,7 +106,7 @@ choose_context_interactive() {
   local choice
   choice="$(_KUBECTX_FORCE_COLOR=1 \
     FZF_DEFAULT_COMMAND="${SELF_CMD}" \
-    fzf --ansi || true)"
+    fzf --ansi -q "$1" -1 || true)"
   if [[ -z "${choice}" ]]; then
     echo 2>&1 "error: you did not choose any of the options"
     exit 1
@@ -184,7 +184,7 @@ main() {
 
   if [[ "$#" -eq 0 ]]; then
     if [[ -t 1 &&  -z "${KUBECTX_IGNORE_FZF:-}" && "$(type fzf &>/dev/null; echo $?)" -eq 0 ]]; then
-      choose_context_interactive
+      choose_context_interactive ""
     else
       list_contexts
     fi
@@ -211,7 +211,7 @@ main() {
     elif [[ "${1}" =~ (.+)=(.+) ]]; then
       rename_context "${BASH_REMATCH[2]}" "${BASH_REMATCH[1]}"
     else
-      set_context "${1}"
+      choose_context_interactive "${1}"
     fi
   else
     usage

--- a/kubens
+++ b/kubens
@@ -106,7 +106,7 @@ choose_namespace_interactive() {
   local choice
   choice="$(_KUBECTX_FORCE_COLOR=1 \
     FZF_DEFAULT_COMMAND="${SELF_CMD}" \
-    fzf --ansi || true)"
+    fzf --ansi -q "$1" -1 || true)"
   if [[ -z "${choice}" ]]; then
     echo 2>&1 "error: you did not choose any of the options"
     exit 1
@@ -186,7 +186,7 @@ main() {
 
   if [[ "$#" -eq 0 ]]; then
     if [[ -t 1 && -z ${KUBECTX_IGNORE_FZF:-} && "$(type fzf &>/dev/null; echo $?)" -eq 0 ]]; then
-      choose_namespace_interactive
+      choose_namespace_interactive ""
     else
       list_namespaces
     fi
@@ -202,7 +202,7 @@ main() {
     elif [[ "${1}" =~ (.+)=(.+) ]]; then
       alias_context "${BASH_REMATCH[2]}" "${BASH_REMATCH[1]}"
     else
-      set_namespace "${1}"
+      choose_namespace_interactive "${1}"
     fi
   else
     echo "error: too many flags" >&2


### PR DESCRIPTION
this passes down `$1` to `fzf`, so it may pre-choose something for you.

It looks like this:

![Kapture 2019-03-29 at 13 59 41](https://user-images.githubusercontent.com/245435/55249518-0572ed00-522b-11e9-81e3-80ccb3d113ed.gif)

IMHO it is more practical because I can type `kx something` and even if its not the complete name it may go to what I need already. 🥇 