### PR TITLE
kubectx rename check if old_name is a valid ctx

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -148,6 +148,11 @@ rename_context() {
     old_name="$(current_context)"
   fi
 
+  if ! context_exists "${old_name}"; then
+    echo "error: Context \"${old_name}\" not found, can't rename it." >&2
+    exit 1
+  fi
+
   if context_exists "${new_name}"; then
     echo "Context \"${new_name}\" exists, deleting..." >&2
     $KUBECTL config delete-context "${new_name}" 1>/dev/null 2>&1


### PR DESCRIPTION
Without this safeguard, when user runs `kubectx NEW_NAME=OLD_NAME` where
NEW_NAME is an existing context but OLD_NAME isn't, we end up deleting NEW_NAME
and not doing any renames (because OLD_NAME is not found).

Fixes #136.