### PR TITLE
add a switch --current for printing current namespace

### DIFF
--- a/kubens
+++ b/kubens
@@ -30,6 +30,7 @@ USAGE:
   kubens                    : list the namespaces in the current context
   kubens <NAME>             : change the active namespace of current context
   kubens -                  : switch to the previous namespace in this context
+  kubens -c,--current         : print current namespace
   kubens -h,--help          : show this message
 EOF
 }
@@ -195,6 +196,8 @@ main() {
       usage
     elif [[ "${1}" == "-" ]]; then
       swap_namespace
+    elif [[ "${1}" == '-c' || "${1}" == '--current' ]]; then
+      current_namespace
     elif [[ "${1}" =~ ^-(.*) ]]; then
       echo "error: unrecognized flag \"${1}\"" >&2
       usage


### PR DESCRIPTION
Not sure this belongs in this utility, but I need "current namespace" for other scripts I am using, so here is a patch!

Feel free to delete if not appropriate, or rename it if wanted.