### PR TITLE
Add callback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ Colors in the output can be disabled by setting the
 
 -----
 
+### Custom callback script
+
+If you like to setup custom callback script on context change, you can export `KUBECTX_CALLBACK`. The script will be invoked on any context change. Callback script can take one parameter - context name.
+
+```
+export KUBECTX_CALLBACK="/usr/local/bin/check_env"
+```
+
+-----
+
 ####  Users
 
 | What are others saying about kubectx? |

--- a/kubectx
+++ b/kubectx
@@ -100,6 +100,7 @@ save_context() {
 
 switch_context() {
   $KUBECTL config use-context "${1}"
+  switch_callback "${1}"
 }
 
 choose_context_interactive() {
@@ -112,6 +113,17 @@ choose_context_interactive() {
     exit 1
   else
     set_context "${choice}"
+  fi
+}
+
+switch_callback() {
+  if [ ! -z "${KUBECTX_CALLBACK:-}" ]; then
+    if hash "${KUBECTX_CALLBACK}" 2> /dev/null; then
+      ${KUBECTX_CALLBACK} "${1}"
+    else
+      echo >&2 "callback script ($KUBECTX_CALLBACK) not found"
+      exit 1
+    fi
   fi
 }
 

--- a/test/callback_script
+++ b/test/callback_script
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+touch callback_test_file

--- a/test/kubectx.bats
+++ b/test/kubectx.bats
@@ -212,3 +212,13 @@ load common
   [ "$status" -eq 0 ]
   [[ "$output" = "user2@cluster1" ]]
 }
+
+@test "setup callback" {
+  use_config config1
+
+  export KUBECTX_CALLBACK="${PWD}/test/callback_script"
+  run ${COMMAND} user1@cluster1
+  echo "$output"
+  [ -f "${PWD}/callback_test_file" ]
+}
+


### PR DESCRIPTION
Changing context may trigger some actions like sending a notification,
background color change, or changing network setup.
kubectx callback allows a user to provide a script which will be invoked
during context change.

This 20 second video shows an example usecase:
https://drive.google.com/file/d/1i5o7Y5zra1seLP2xsctMxXhDQdS81V-g/view?usp=sharing