### PR TITLE
Allow kubens to work with client-go credential plugins

### DIFF
--- a/kubens
+++ b/kubens
@@ -24,6 +24,10 @@ IFS=$'\n\t'
 SELF_CMD="$0"
 KUBENS_DIR="${XDG_CACHE_HOME:-$HOME/.kube}/kubens"
 
+exec {STDIN}>&0
+exec {STDOUT}>&1
+exec {STDERR}>&2
+
 usage() {
   cat <<"EOF"
 USAGE:
@@ -58,6 +62,15 @@ current_context() {
 }
 
 get_namespaces() {
+  $KUBECTL get namespaces 2>/dev/null 1>/dev/null
+  if [[ $? -ne 0 ]]; then
+    $KUBECTL get namespaces >&$STDOUT 2>&$STDERR <&$STDIN
+
+    if [[ $? -ne 0 ]]; then
+      return $?
+    fi
+  fi
+
   $KUBECTL get namespaces -o=jsonpath='{range .items[*].metadata.name}{@}{"\n"}{end}'
 }
 

--- a/kubens
+++ b/kubens
@@ -24,6 +24,9 @@ IFS=$'\n\t'
 SELF_CMD="$0"
 KUBENS_DIR="${XDG_CACHE_HOME:-$HOME/.kube}/kubens"
 
+# Assign the main process' standard streams to variables so that they can be
+# used to invoke kubectl interactively while in a function. Interactively
+# invoking kubectl allows any configured client-go auth plugins to trigger.
 exec {STDIN}>&0
 exec {STDOUT}>&1
 exec {STDERR}>&2
@@ -63,12 +66,20 @@ current_context() {
 
 get_namespaces() {
   name_jsonpath='{range .items[*].metadata.name}{@}{"\n"}{end}'
-  namespaces=$($KUBECTL get namespaces -o=jsonpath="${name_jsonpath}" 2>/dev/null)
+  namespaces="$($KUBECTL get namespaces -o=jsonpath="${name_jsonpath}" 2>/dev/null)"
   if [[ $? -eq 0 ]]; then
     echo "${namespaces}"
     return 0
   fi
 
+  # If kubectl fails to get namespaces it might be due to the need authenticate
+  # with the cluster via a client-go authentication plugin. Auth plugins are
+  # only triggered when kubectl is invoked with an interactive STDOUT, so the
+  # original get namespaces attempt won't trigger them.
+  #
+  # This auth attempt with interactive standard streams will trigger any
+  # existing auth plugins. If the auth is successful then the subsequent get
+  # namespaces attempt will succeed and return the necessary namespace output.
   $KUBECTL auth can-i get namespaces --quiet 1>&$STDOUT 2>&$STDERR <&$STDIN
   if [[ $? -ne 0 ]]; then
     return $?

--- a/kubens
+++ b/kubens
@@ -62,16 +62,19 @@ current_context() {
 }
 
 get_namespaces() {
-  $KUBECTL auth can-i get namespaces 1>/dev/null 2>/dev/null
-  if [[ $? -ne 0 ]]; then
-    $KUBECTL auth can-i get namespaces --quiet 1>&$STDOUT 2>&$STDERR <&$STDIN
-
-    if [[ $? -ne 0 ]]; then
-      return $?
-    fi
+  name_jsonpath='{range .items[*].metadata.name}{@}{"\n"}{end}'
+  namespaces=$($KUBECTL get namespaces -o=jsonpath="${name_jsonpath}" 2>/dev/null)
+  if [[ $? -eq 0 ]]; then
+    echo "${namespaces}"
+    return 0
   fi
 
-  $KUBECTL get namespaces -o=jsonpath='{range .items[*].metadata.name}{@}{"\n"}{end}'
+  $KUBECTL auth can-i get namespaces --quiet 1>&$STDOUT 2>&$STDERR <&$STDIN
+  if [[ $? -ne 0 ]]; then
+    return $?
+  fi
+
+  $KUBECTL get namespaces -o=jsonpath="${name_jsonpath}"
 }
 
 escape_context_name() {

--- a/kubens
+++ b/kubens
@@ -62,9 +62,9 @@ current_context() {
 }
 
 get_namespaces() {
-  $KUBECTL get namespaces 2>/dev/null 1>/dev/null
+  $KUBECTL auth can-i get namespaces 1>/dev/null 2>/dev/null
   if [[ $? -ne 0 ]]; then
-    $KUBECTL get namespaces >&$STDOUT 2>&$STDERR <&$STDIN
+    $KUBECTL auth can-i get namespaces --quiet 1>&$STDOUT 2>&$STDERR <&$STDIN
 
     if [[ $? -ne 0 ]]; then
       return $?


### PR DESCRIPTION
Client-go, and by extension, kubectl, has the ability to run configurable commands to interactively prompt a user to authenticate. This system is known as [client-go credential plugins](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins).

Kubectl will only run credential plugins when it believes its STDOUT is an interactive TTY. Since kubens invokes `kubectl get namespaces` in a subshell, by default it causes kubectl to bypass its credential plugins.

Since kubens uses the STDOUT of `kubectl get namespaces` we also can't blindly redirect its STDOUT to that of the parent process.

The solution to allow kubens to work correctly with credential plugins is two part:

1. Check if the get namespaces command will succeed, if so, run it like normal
2. If the get namespaces command will fail, then run it again, interactively, by redirecting its inputs and outputs to those of the parent process. After the user successfully authenticates then run the get namespaces command one final time without any output redirection