### PR TITLE
Fuzzy-set if given name is not an exact match

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -104,10 +104,11 @@ switch_context() {
 }
 
 choose_context_interactive() {
+  local partial_name="${1:-}"
   local choice
   choice="$(_KUBECTX_FORCE_COLOR=1 \
     FZF_DEFAULT_COMMAND="${SELF_CMD}" \
-    fzf --ansi || true)"
+    fzf --ansi --query="$partial_name" || true)"
   if [[ -z "${choice}" ]]; then
     echo 2>&1 "error: you did not choose any of the options"
     exit 1
@@ -120,7 +121,7 @@ set_context() {
   local prev
   prev="$(current_context)" || exit_err "error getting current context"
 
-  switch_context "${1}"
+  switch_context "${1}" || return 1
 
   if [[ "${prev}" != "${1}" ]]; then
     save_context "${prev}"
@@ -188,8 +189,13 @@ main() {
     exit 1
   fi
 
+  local interactive
+  if [[ -t 1 &&  -z "${KUBECTX_IGNORE_FZF:-}" && "$(type fzf &>/dev/null; echo $?)" -eq 0 ]]; then
+    interactive=y
+  fi
+
   if [[ "$#" -eq 0 ]]; then
-    if [[ -t 1 &&  -z "${KUBECTX_IGNORE_FZF:-}" && "$(type fzf &>/dev/null; echo $?)" -eq 0 ]]; then
+    if [[ -n "${interactive:-}" ]]; then
       choose_context_interactive
     else
       list_contexts
@@ -222,7 +228,12 @@ main() {
     elif [[ "${1}" =~ (.+)=(.+) ]]; then
       rename_context "${BASH_REMATCH[2]}" "${BASH_REMATCH[1]}"
     else
-      set_context "${1}"
+      if [[ -n "${interactive:-}" ]]; then
+        echo doing it
+        set_context "$1" || choose_context_interactive "$1"
+      else
+        set_context "$1"
+      fi
     fi
   else
     usage

--- a/kubens
+++ b/kubens
@@ -98,6 +98,7 @@ switch_namespace() {
 }
 
 choose_namespace_interactive() {
+  local partial_name="${1:-}"
   # directly calling kubens via fzf might fail with a cryptic error like
   # "$FZF_DEFAULT_COMMAND failed", so try to see if we can list namespaces
   # locally first
@@ -109,7 +110,7 @@ choose_namespace_interactive() {
   local choice
   choice="$(_KUBECTX_FORCE_COLOR=1 \
     FZF_DEFAULT_COMMAND="${SELF_CMD}" \
-    fzf --ansi || true)"
+    fzf --ansi --query="$partial_name" || true)"
   if [[ -z "${choice}" ]]; then
     echo 2>&1 "error: you did not choose any of the options"
     exit 1
@@ -131,7 +132,7 @@ set_namespace() {
     fi
   else
     echo "error: no namespace exists with name \"${1}\".">&2
-    exit 1
+    return 1
   fi
 }
 
@@ -187,8 +188,13 @@ main() {
     fi
   fi
 
+  local interactive
+  if [[ -t 1 && -z ${KUBECTX_IGNORE_FZF:-} && "$(type fzf &>/dev/null; echo $?)" -eq 0 ]]; then
+    interactive=y
+  fi
+
   if [[ "$#" -eq 0 ]]; then
-    if [[ -t 1 && -z ${KUBECTX_IGNORE_FZF:-} && "$(type fzf &>/dev/null; echo $?)" -eq 0 ]]; then
+    if [[ -n "${interactive:-}" ]]; then
       choose_namespace_interactive
     else
       list_namespaces
@@ -207,7 +213,11 @@ main() {
     elif [[ "${1}" =~ (.+)=(.+) ]]; then
       alias_context "${BASH_REMATCH[2]}" "${BASH_REMATCH[1]}"
     else
-      set_namespace "${1}"
+      if [[ -n "${interactive:-}" ]]; then
+        set_namespace "$1" 2>/dev/null || choose_namespace_interactive "$1"
+      else
+        set_namespace "$1"
+      fi
     fi
   else
     echo "error: too many flags" >&2


### PR DESCRIPTION
Currently,

```
$ kubens def
error: no namespace exists with name "def".
```

This commit instead drops the user into fzf, where the first result is
probably 'default', which they can hit enter to accept. If it is the
only result, it is *not* accepted by default, giving the user a chance
to confirm.

fzf is only used according to the existing rules: installed, stdout is a
tty, and disabling env var not set.