### PR TITLE
Disable preview when fuzzy-finding

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -107,7 +107,7 @@ choose_context_interactive() {
   local choice
   choice="$(_KUBECTX_FORCE_COLOR=1 \
     FZF_DEFAULT_COMMAND="${SELF_CMD}" \
-    fzf --ansi || true)"
+    fzf --ansi --no-preview || true)"
   if [[ -z "${choice}" ]]; then
     echo 2>&1 "error: you did not choose any of the options"
     exit 1

--- a/kubens
+++ b/kubens
@@ -109,7 +109,7 @@ choose_namespace_interactive() {
   local choice
   choice="$(_KUBECTX_FORCE_COLOR=1 \
     FZF_DEFAULT_COMMAND="${SELF_CMD}" \
-    fzf --ansi || true)"
+    fzf --ansi --no-preview || true)"
   if [[ -z "${choice}" ]]; then
     echo 2>&1 "error: you did not choose any of the options"
     exit 1


### PR DESCRIPTION
The user may have global settings that enable the preview pane in fzf.

Whatever the preview command is set as, it probably doesn't render
anything meaningful for kubens - I can't think what would be.

For kubectx, the context yaml itself would _maybe_ be helpful, but it
likely contains secrets, so I don't personally think I'd find it useful
enough to get into.

This commit thus disables the preview, so that if the user did have it
enabled, there's now no pane where there would previously have probably
been an error, such as:

    [bat error]: '<namespace>': No such file or directory (os error 2)