### PR TITLE
Option for printing  only the current context/namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ USAGE:
   kubectx                   : list the contexts
   kubectx <NAME>            : switch to context <NAME>
   kubectx -                 : switch to the previous context
+  kubectx -c                : prints the current context only
   kubectx <NEW_NAME>=<NAME> : rename context <NAME> to <NEW_NAME>
   kubectx <NEW_NAME>=.      : rename current-context to <NEW_NAME>
   kubectx -d <NAME>         : delete context <NAME> ('.' for current-context)

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ USAGE:
   kubens                    : list the namespaces
   kubens <NAME>             : change the active namespace
   kubens -                  : switch to the previous namespace
+  kubens -c                 : print only the current namespace in the current context
 ```
 
 

--- a/kubectx
+++ b/kubectx
@@ -30,6 +30,7 @@ USAGE:
   kubectx                       : list the contexts
   kubectx <NAME>                : switch to context <NAME>
   kubectx -                     : switch to the previous context
+  kubectx -c                    : prints the current context only
   kubectx <NEW_NAME>=<NAME>     : rename context <NAME> to <NEW_NAME>
   kubectx <NEW_NAME>=.          : rename current-context to <NEW_NAME>
   kubectx -d <NAME> [<NAME...>] : delete context <NAME> ('.' for current-context)
@@ -193,6 +194,13 @@ main() {
     else
       list_contexts
     fi
+  elif [[ "${1}" == "-c" ]]; then
+    if [[ "$#" -ne 1 ]]; then
+      echo "error: too many arguments" >&2
+      usage
+      exit 1
+    fi
+    current_context
   elif [[ "${1}" == "-d" ]]; then
     if [[ "$#" -lt 2 ]]; then
       echo "error: missing context NAME" >&2

--- a/kubens
+++ b/kubens
@@ -30,6 +30,7 @@ USAGE:
   kubens                    : list the namespaces in the current context
   kubens <NAME>             : change the active namespace of current context
   kubens -                  : switch to the previous namespace in this context
+  kubens -c                 : print only the current namespace in the current context
   kubens -h,--help          : show this message
 EOF
 }
@@ -193,6 +194,8 @@ main() {
   elif [[ "$#" -eq 1 ]]; then
     if [[ "${1}" == '-h' || "${1}" == '--help' ]]; then
       usage
+    elif [[ "${1}" == '-c' ]]; then
+      current_namespace
     elif [[ "${1}" == "-" ]]; then
       swap_namespace
     elif [[ "${1}" =~ ^-(.*) ]]; then


### PR DESCRIPTION
As of now, when we use the utilities `kubectx` or `kubens` we get the list of all the context or namespaces respectively.  
But if we want to let's say apply a set of config files from a script(using `kubectl`), but before that we want to confirm the current context/namespace we've set then we can use the `-c` option.

PS : of course we can just add one line to change to desired context/namespace before & after applying the config files but I think it's better to have a specific option to just get the current values for the context/namespace.

Also, as we already have `kubectl config current-context` but I think as `kubectx` is quite handy (& widely used) it's better to have `-c` option with it.

Please let me know your opinion! 