### PR TITLE
Added new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,19 @@ kubectx is a utility to manage and switch between kubectl(1) contexts.
 
 ```
 USAGE:
-  kubectx                   : list the contexts
-  kubectx <NAME>            : switch to context <NAME>
-  kubectx -                 : switch to the previous context
-  kubectx <NEW_NAME>=<NAME> : rename context <NAME> to <NEW_NAME>
-  kubectx <NEW_NAME>=.      : rename current-context to <NEW_NAME>
-  kubectx -d <NAME>         : delete context <NAME> ('.' for current-context)
-                              (this command won't delete the user/cluster entry
-                              that is used by the context)
+  kubectx                       : list the contexts
+  kubectx -a <KUBECONFIG FILE>  : add cluster to ~/.kube/config file
+  kubectx -u                    : unset current context
+  kubectx <NAME>                : switch to context <NAME>
+  kubectx -                     : switch to the previous context
+  kubectx <NEW_NAME>=<NAME>     : rename context <NAME> to <NEW_NAME>
+  kubectx <NEW_NAME>=.          : rename current-context to <NEW_NAME>
+  kubectx -d <NAME> [<NAME...>] : delete context <NAME> ('.' for current-context)
+                                  (this command won't delete the user/cluster entry
+                                  that is used by the context)
+  kubectx -l                    : list all contexts
+
+  kubectx -h,--help             : show this message
 ```
 
 ### Usage

--- a/kubectx
+++ b/kubectx
@@ -35,6 +35,8 @@ USAGE:
   kubectx -d <NAME> [<NAME...>] : delete context <NAME> ('.' for current-context)
                                   (this command won't delete the user/cluster entry
                                   that is used by the context)
+  kubectx -l	                : list all contexts
+  kubectx -u	                : unset current context
 
   kubectx -h,--help             : show this message
 EOF
@@ -177,6 +179,11 @@ delete_context() {
   $KUBECTL config delete-context "${ctx}"
 }
 
+unset_current_context() {
+  echo "Unsetting current context"... >&2
+  $KUBECTL config unset current-context
+}
+
 main() {
   if hash kubectl 2>/dev/null; then
     KUBECTL=kubectl
@@ -209,6 +216,10 @@ main() {
       swap_context
     elif [[ "${1}" == '-h' || "${1}" == '--help' ]]; then
       usage
+    elif [[ "${1}" == '-u' ]]; then
+      unset_current_context
+    elif [[ "${1}" == '-l' ]]; then
+      list_contexts
     elif [[ "${1}" =~ ^-(.*) ]]; then
       echo "error: unrecognized flag \"${1}\"" >&2
       usage

--- a/kubectx
+++ b/kubectx
@@ -32,7 +32,6 @@ USAGE:
   kubectx -u                    : unset current context
   kubectx <NAME>                : switch to context <NAME>
   kubectx -                     : switch to the previous context
-  kubectx -c, --current         : show the current context name
   kubectx <NEW_NAME>=<NAME>     : rename context <NAME> to <NEW_NAME>
   kubectx <NEW_NAME>=.          : rename current-context to <NEW_NAME>
   kubectx -d <NAME> [<NAME...>] : delete context <NAME> ('.' for current-context)
@@ -249,11 +248,6 @@ main() {
   elif [[ "$#" -eq 1 ]]; then
     if [[ "${1}" == "-" ]]; then
       swap_context
-    elif [[ "${1}" == '-c' || "${1}" == '--current' ]]; then
-      # we don't call current_context here for two reasons:
-      # - it does not fail when current-context property is not set
-      # - it does not return a trailing newline
-      kubectl config current-context
     elif [[ "${1}" == '-h' || "${1}" == '--help' ]]; then
       usage
     elif [[ "${1}" == '-u' ]]; then

--- a/kubectx
+++ b/kubectx
@@ -28,6 +28,8 @@ usage() {
   cat <<"EOF"
 USAGE:
   kubectx                       : list the contexts
+  kubectx -a <KUBECONFIG FILE>  : add cluster to ~/.kube/config file
+  kubectx -u                    : unset current context
   kubectx <NAME>                : switch to context <NAME>
   kubectx -                     : switch to the previous context
   kubectx <NEW_NAME>=<NAME>     : rename context <NAME> to <NEW_NAME>
@@ -36,7 +38,6 @@ USAGE:
                                   (this command won't delete the user/cluster entry
                                   that is used by the context)
   kubectx -l	                : list all contexts
-  kubectx -u	                : unset current context
 
   kubectx -h,--help             : show this message
 EOF
@@ -53,6 +54,10 @@ current_context() {
 
 get_contexts() {
   $KUBECTL config get-contexts -o=name | sort -n
+}
+
+get_clusters() {
+  $KUBECTL config get-clusters | sort -n
 }
 
 list_contexts() {
@@ -142,6 +147,28 @@ context_exists() {
   grep -q ^"${1}"\$ <($KUBECTL config get-contexts -o=name)
 }
 
+add_context(){
+  new_context=$1
+  if test -f "$new_context"; then
+    if test `find "$new_context" -mmin +5`
+    then
+      echo "File $new_context is too old, is it correct?"
+    else
+      export KUBECONFIG=~/.kube/config:$new_context
+      $KUBECTL config view --flatten --merge  > /tmp/config
+      cp /tmp/config /home/chiaretto/.kube/config
+      echo "Context added..." >&2
+      unset KUBECONFIG
+    fi
+  else
+      echo "File $new_context not found"
+  fi
+}
+
+cluster_exists() {
+  grep -q ^"${1}"\$ <($KUBECTL config get-clusters -o=name)
+}
+
 rename_context() {
   local old_name="${1}"
   local new_name="${2}"
@@ -166,6 +193,7 @@ rename_context() {
 delete_contexts() {
   for i in "${@}"; do
     delete_context "${i}"
+    delete_cluster "${i}"
   done
 }
 
@@ -177,6 +205,13 @@ delete_context() {
   fi
   echo "Deleting context \"${ctx}\"..." >&2
   $KUBECTL config delete-context "${ctx}"
+}
+
+delete_cluster() {
+  local cluster
+  cluster="${1}"
+  echo "Deleting cluster \"${cluster}\"..." >&2
+  $KUBECTL config delete-cluster "${cluster}"
 }
 
 unset_current_context() {
@@ -207,6 +242,13 @@ main() {
       exit 1
     fi
     delete_contexts "${@:2}"
+    elif [[ "${1}" == "-a" ]]; then
+    if [[ "$#" -lt 2 ]]; then
+      echo "error: missing new context file" >&2
+      usage
+      exit 1
+    fi
+    add_context "${@:2}"
   elif [[ "$#" -gt 1 ]]; then
     echo "error: too many arguments" >&2
     usage
@@ -217,7 +259,7 @@ main() {
     elif [[ "${1}" == '-h' || "${1}" == '--help' ]]; then
       usage
     elif [[ "${1}" == '-u' ]]; then
-      unset_current_context
+      unset_current_context     
     elif [[ "${1}" == '-l' ]]; then
       list_contexts
     elif [[ "${1}" =~ ^-(.*) ]]; then

--- a/kubectx
+++ b/kubectx
@@ -32,6 +32,7 @@ USAGE:
   kubectx -u                    : unset current context
   kubectx <NAME>                : switch to context <NAME>
   kubectx -                     : switch to the previous context
+  kubectx -c, --current         : show the current context name
   kubectx <NEW_NAME>=<NAME>     : rename context <NAME> to <NEW_NAME>
   kubectx <NEW_NAME>=.          : rename current-context to <NEW_NAME>
   kubectx -d <NAME> [<NAME...>] : delete context <NAME> ('.' for current-context)
@@ -256,6 +257,11 @@ main() {
   elif [[ "$#" -eq 1 ]]; then
     if [[ "${1}" == "-" ]]; then
       swap_context
+    elif [[ "${1}" == '-c' || "${1}" == '--current' ]]; then
+      # we don't call current_context here for two reasons:
+      # - it does not fail when current-context property is not set
+      # - it does not return a trailing newline
+      kubectl config current-context
     elif [[ "${1}" == '-h' || "${1}" == '--help' ]]; then
       usage
     elif [[ "${1}" == '-u' ]]; then

--- a/kubectx
+++ b/kubectx
@@ -194,7 +194,6 @@ rename_context() {
 delete_contexts() {
   for i in "${@}"; do
     delete_context "${i}"
-    delete_cluster "${i}"
   done
 }
 
@@ -206,13 +205,6 @@ delete_context() {
   fi
   echo "Deleting context \"${ctx}\"..." >&2
   $KUBECTL config delete-context "${ctx}"
-}
-
-delete_cluster() {
-  local cluster
-  cluster="${1}"
-  echo "Deleting cluster \"${cluster}\"..." >&2
-  $KUBECTL config delete-cluster "${cluster}"
 }
 
 unset_current_context() {

--- a/kubens
+++ b/kubens
@@ -30,6 +30,7 @@ USAGE:
   kubens                    : list the namespaces in the current context
   kubens <NAME>             : change the active namespace of current context
   kubens -                  : switch to the previous namespace in this context
+  kubens -c, --current      : show the current namespace
   kubens -h,--help          : show this message
 EOF
 }
@@ -67,6 +68,8 @@ escape_context_name() {
 
 namespace_file() {
   local ctx="$(escape_context_name "${1}")"
+
+  ctx="$(escape_context_name "${1}")"
   echo "${KUBENS_DIR}/${ctx}"
 }
 
@@ -195,6 +198,8 @@ main() {
       usage
     elif [[ "${1}" == "-" ]]; then
       swap_namespace
+    elif [[ "${1}" == '-c' || "${1}" == '--current' ]]; then
+      current_namespace
     elif [[ "${1}" =~ ^-(.*) ]]; then
       echo "error: unrecognized flag \"${1}\"" >&2
       usage

--- a/kubens
+++ b/kubens
@@ -30,7 +30,6 @@ USAGE:
   kubens                    : list the namespaces in the current context
   kubens <NAME>             : change the active namespace of current context
   kubens -                  : switch to the previous namespace in this context
-  kubens -c, --current      : show the current namespace
   kubens -h,--help          : show this message
 EOF
 }
@@ -68,8 +67,6 @@ escape_context_name() {
 
 namespace_file() {
   local ctx="$(escape_context_name "${1}")"
-
-  ctx="$(escape_context_name "${1}")"
   echo "${KUBENS_DIR}/${ctx}"
 }
 
@@ -198,8 +195,6 @@ main() {
       usage
     elif [[ "${1}" == "-" ]]; then
       swap_namespace
-    elif [[ "${1}" == '-c' || "${1}" == '--current' ]]; then
-      current_namespace
     elif [[ "${1}" =~ ^-(.*) ]]; then
       echo "error: unrecognized flag \"${1}\"" >&2
       usage


### PR DESCRIPTION
- Added `-a` parameter to add new context to '/.kube/config based on a kubeconfig file.

`kubectx -a /tmp/kubeconfig`

- Added `-u` parameter to unset context.

`kubectx -u`

- Added `-l` parameter to list all contexts