### PR TITLE
Add zsh completion for kubectx subcommand (-d)

### DIFF
--- a/completion/kubectx.zsh
+++ b/completion/kubectx.zsh
@@ -2,11 +2,17 @@
 
 local KUBECTX="${HOME}/.kube/kubectx"
 PREV=""
+
+local all_contexts="$(kubectl config get-contexts --output='name')"
 if [ -f "$KUBECTX" ]; then
     # show '-' only if there's a saved previous context
     local PREV=$(cat "${KUBECTX}")
-    _arguments "1: :(-
-        $(kubectl config get-contexts --output='name'))"
+
+    _arguments \
+      "-d:*: :(${all_contexts})" \
+      "(- *): :(- ${all_contexts})"
 else
-    _arguments "1: :($(kubectl config get-contexts --output='name'))"
+    _arguments \
+      "-d:*: :(${all_contexts})" \
+      "(- *): :(${all_contexts})"
 fi


### PR DESCRIPTION
- Add basic zsh completion for subcommand -d.

Fixes https://github.com/ahmetb/kubectx/issues/40