### PR TITLE
changed help in kubens, return had a typo

### DIFF
--- a/cmd/kubens/help.go
+++ b/cmd/kubens/help.go
@@ -40,5 +40,5 @@ func selfName() string {
 	if strings.HasPrefix(me, pluginPrefix) {
 		return "kubectl " + strings.TrimPrefix(me, pluginPrefix)
 	}
-	return "kubectx"
+	return "kubens"
 }


### PR DESCRIPTION
**Version**: 0.9.0
**Command**: `kubens --help`
**Expected**: the command has to show the usage 
**Command without fix in actual version**:
```
➜ kubens --help                                                                                   
USAGE:
  kubectx                    : list the namespaces in the current context
  kubectx <NAME>             : change the active namespace of current context
  kubectx -                  : switch to the previous namespace in this context
  kubectx -c, --current      : show the current namespace
  kubectx -h,--help          : show this message

```
