### PR TITLE
Release for arm64 (armv8) and armhf (armv6), armv7

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,6 +15,9 @@ builds:
     - windows
   goarch:
     - amd64
+    - arm
+    - arm64
+  goarm: [6, 7]
 - id: kubens
   main: ./cmd/kubens
   binary: kubens
@@ -26,9 +29,18 @@ builds:
     - windows
   goarch:
     - amd64
+    - arm
+    - arm64
+  goarm: [6, 7]
 archives:
 - id: kubectx-archive
-  name_template: "kubectx_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+  name_template: |-
+    kubectx_{{ .Tag }}_{{ .Os }}_{{ .Arch -}}
+    {{- with .Arm -}}
+      {{- if (eq . "6") -}}hf
+      {{- else -}}v{{- . -}}
+      {{- end -}}
+    {{- end -}}
   builds:
     - kubectx
   replacements:
@@ -39,7 +51,13 @@ archives:
       format: zip
   files: ["LICENSE"]
 - id: kubens-archive
-  name_template: "kubens_{{ .Tag }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+  name_template: |-
+    kubens_{{ .Tag }}_{{ .Os }}_{{ .Arch -}}
+    {{- with .Arm -}}
+      {{- if (eq . "6") -}}hf
+      {{- else -}}v{{- . -}}
+      {{- end -}}
+    {{- end -}}
   builds:
     - kubens
   replacements:


### PR DESCRIPTION
Add builds for:

- armv6 (GOOS=arm64 GOOS=linux)
- armhf (GOARM=6 GOOS=linux GOARCH=arm)
- armv7 (GOARM=7 GOOS=linux GOARCH=arm)

Update name templates accordingly.

Fixes #213.