### PR TITLE
Fix color output on Windows

### DIFF
--- a/cmd/kubectx/main.go
+++ b/cmd/kubectx/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ahmetb/kubectx/internal/cmdutil"
 	"github.com/ahmetb/kubectx/internal/env"
 	"github.com/ahmetb/kubectx/internal/printer"
+	"github.com/fatih/color"
 )
 
 type Op interface {
@@ -15,15 +16,15 @@ type Op interface {
 }
 
 func main() {
-	cmdutil.PrintDeprecatedEnvWarnings(os.Stderr, os.Environ())
+	cmdutil.PrintDeprecatedEnvWarnings(color.Error, os.Environ())
 
 	op := parseArgs(os.Args[1:])
-	if err := op.Run(os.Stdout, os.Stderr); err != nil {
-		printer.Error(os.Stderr, err.Error())
+	if err := op.Run(color.Output, color.Error); err != nil {
+		printer.Error(color.Error, err.Error())
 
 		if _, ok := os.LookupEnv(env.EnvDebug); ok {
 			// print stack trace in verbose mode
-			fmt.Fprintf(os.Stderr, "[DEBUG] error: %+v\n", err)
+			fmt.Fprintf(color.Error, "[DEBUG] error: %+v\n", err)
 		}
 		defer os.Exit(1)
 	}

--- a/cmd/kubens/main.go
+++ b/cmd/kubens/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ahmetb/kubectx/internal/cmdutil"
 	"github.com/ahmetb/kubectx/internal/env"
 	"github.com/ahmetb/kubectx/internal/printer"
+	"github.com/fatih/color"
 )
 
 type Op interface {
@@ -15,14 +16,14 @@ type Op interface {
 }
 
 func main() {
-	cmdutil.PrintDeprecatedEnvWarnings(os.Stderr, os.Environ())
+	cmdutil.PrintDeprecatedEnvWarnings(color.Error, os.Environ())
 	op := parseArgs(os.Args[1:])
-	if err := op.Run(os.Stdout, os.Stderr); err != nil {
-		printer.Error(os.Stderr, err.Error())
+	if err := op.Run(color.Output, color.Error); err != nil {
+		printer.Error(color.Error, err.Error())
 
 		if _, ok := os.LookupEnv(env.EnvDebug); ok {
 			// print stack trace in verbose mode
-			fmt.Fprintf(os.Stderr, "[DEBUG] error: %+v\n", err)
+			fmt.Fprintf(color.Error, "[DEBUG] error: %+v\n", err)
 		}
 		defer os.Exit(1)
 	}


### PR DESCRIPTION
Output on Windows showed the ANSI escape sequences. This uses the colorable writers to display the colored output.

Tested in PowerShell, PowerShell Core, and WSL.