### PR TITLE
Introduce -n flag that shows indexes of contexts and allows to set current based on index

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ USAGE:
                               (this command won't delete the user/cluster entry
                               that is used by the context)
   kubectx -u, --unset       : unset the current context
+  kubectx -n<NUM>           : list the context with index numbers
+                              if <NUM> is specified - switch to
+                              context with that number
 ```
 
 ### Usage

--- a/kubectx
+++ b/kubectx
@@ -145,20 +145,6 @@ set_context() {
   fi
 }
 
-set_nth_context() {
-  local prev
-  prev="$(current_context)" || exit_err "error getting current context"
-
-  local nth
-  nth=`get_contexts | tail -n+"${1}" | head -n1`
-
-  switch_context "${nth}"
-
-  if [[ "${prev}" != "${nth}" ]]; then
-    save_context "${prev}"
-  fi
-}
-
 swap_context() {
   local ctx
   ctx="$(read_context)"

--- a/kubectx
+++ b/kubectx
@@ -44,6 +44,9 @@ USAGE:
                                   (this command won't delete the user/cluster entry
                                   that is used by the context)
   $SELF -u, --unset           : unset the current context
+  $SELF -n<NUM>               : list the context with index numbers
+                                  if <NUM> is specified - switch to
+                                  context with that number
 
   $SELF -h,--help             : show this message
 EOF
@@ -77,17 +80,24 @@ list_contexts() {
   cur_ctx_fg=${KUBECTX_CURRENT_FGCOLOR:-$yellow}
   cur_ctx_bg=${KUBECTX_CURRENT_BGCOLOR:-$darkbg}
 
+  local num=0
+  local fnum=""
+
   for c in $ctx_list; do
+  if [[ -n "${show_numbers+x}" ]]; then
+    num="$((num+1))"
+    fnum=$(printf "%2d%s. " $num)
+  fi
   if [[ -n "${_KUBECTX_FORCE_COLOR:-}" || \
        -t 1 && -z "${NO_COLOR:-}" ]]; then
     # colored output mode
     if [[ "${c}" = "${cur}" ]]; then
-      echo "${cur_ctx_bg}${cur_ctx_fg}${c}${normal}"
+      echo "${fnum}${cur_ctx_bg}${cur_ctx_fg}${c}${normal}"
     else
-      echo "${c}"
+      echo "${fnum}${c}"
     fi
   else
-    echo "${c}"
+    echo "${fnum}${c}"
   fi
   done
 }
@@ -131,6 +141,20 @@ set_context() {
   switch_context "${1}"
 
   if [[ "${prev}" != "${1}" ]]; then
+    save_context "${prev}"
+  fi
+}
+
+set_nth_context() {
+  local prev
+  prev="$(current_context)" || exit_err "error getting current context"
+
+  local nth
+  nth=`get_contexts | tail -n+"${1}" | head -n1`
+
+  switch_context "${nth}"
+
+  if [[ "${prev}" != "${nth}" ]]; then
     save_context "${prev}"
   fi
 }
@@ -214,6 +238,21 @@ main() {
       exit 1
     fi
     delete_contexts "${@:2}"
+  elif [[ "${1}" == -n* ]]; then
+    if [[ "${1}" == '-n' ]]; then
+	  show_numbers=true
+	  list_contexts
+	else
+	  local regex="^-n([0-9]+)$"
+	  if [[ "${1}" =~ $regex ]]; then
+	    local ctx_name=`get_contexts | tail -n+"${BASH_REMATCH[1]}" | head -n1`
+	    set_context "${ctx_name}"
+	  else
+	    echo "error: wrong number format for -n option" >&2
+        usage
+        exit 1
+	  fi
+	fi
   elif [[ "$#" -gt 1 ]]; then
     echo "error: too many arguments" >&2
     usage


### PR DESCRIPTION
The feature might be useful for people who have to deal with lots of contexts all the time.
Example of use:
```
> kubectx -n
 1. foo-bar-context
 2. follow-the-white-rabbit
 3. another-context
 4. shaken-not-stirred
 5. bar-foo-context
 6. here-is-another-one
> kubectx -n2
Switched to context "follow-the-white-rabbit".
```