### PR TITLE
fix: improve kubectx completion on fish

### DIFF
--- a/completion/kubectx.fish
+++ b/completion/kubectx.fish
@@ -1,3 +1,10 @@
 # kubectx
-complete -f -c kubectx -a "- (kubectl config get-contexts --output='name')"
 
+function __fish_kubectx_arg_number -a number
+    set -l cmd (commandline -opc)
+    test (count $cmd) -eq $number
+end
+
+complete -f -c kubectx
+complete -f -x -c kubectx -n '__fish_kubectx_arg_number 1' -a "(kubectl config get-contexts --output='name')"
+complete -f -x -c kubectx -n '__fish_kubectx_arg_number 1' -a "-" -d "switch to the previous namespace in this context"


### PR DESCRIPTION
make `kubens` and `kubectx` completion more similar to each other.