### PR TITLE
make kubectx consistent with kubens wrt. KUBECTL environment variable

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -192,13 +192,15 @@ unset_context() {
 }
 
 main() {
-  if hash kubectl 2>/dev/null; then
-    KUBECTL=kubectl
-  elif hash kubectl.exe 2>/dev/null; then
-    KUBECTL=kubectl.exe
-  else
-    echo >&2 "kubectl is not installed"
-    exit 1
+  if [[ -z "${KUBECTL:-}" ]]; then
+    if hash kubectl 2>/dev/null; then
+      KUBECTL=kubectl
+    elif hash kubectl.exe  2>/dev/null; then
+      KUBECTL=kubectl.exe
+    else
+      echo >&2 "kubectl is not installed"
+      exit 1
+    fi
   fi
 
   if [[ "$#" -eq 0 ]]; then


### PR DESCRIPTION
`kubens` supports providing an environment variable [`KUBECTL`](https://github.com/ahmetb/kubectx/blob/master/kubens#L186-L195) with the location of the `kubectl` binary.

This pull makes `kubectx` consistent with `kubens` with respect to the `KUBECTL` environment variable.