### PR TITLE
add -V/--version flag to go implementations

### DIFF
--- a/cmd/kubectx/flags.go
+++ b/cmd/kubectx/flags.go
@@ -52,6 +52,9 @@ func parseArgs(argv []string) Op {
 		if v == "--help" || v == "-h" {
 			return HelpOp{}
 		}
+		if v == "--version" || v == "-V" {
+			return VersionOp{}
+		}
 		if v == "--current" || v == "-c" {
 			return CurrentOp{}
 		}

--- a/cmd/kubectx/help.go
+++ b/cmd/kubectx/help.go
@@ -39,11 +39,12 @@ func printUsage(out io.Writer) error {
   %PROG% -c, --current         : show the current context name
   %PROG% <NEW_NAME>=<NAME>     : rename context <NAME> to <NEW_NAME>
   %PROG% <NEW_NAME>=.          : rename current-context to <NEW_NAME>
-  %PROG% -u, --unset           : unset the current context  
+  %PROG% -u, --unset           : unset the current context
   %PROG% -d <NAME> [<NAME...>] : delete context <NAME> ('.' for current-context)
   %SPAC%                         (this command won't delete the user/cluster entry
   %SPAC%                          referenced by the context entry)
-  %PROG% -h,--help             : show this message`
+  %PROG% -h,--help             : show this message
+  %PROG% -V,--version          : show version`
 	help = strings.ReplaceAll(help, "%PROG%", selfName())
 	help = strings.ReplaceAll(help, "%SPAC%", strings.Repeat(" ", len(selfName())))
 

--- a/cmd/kubectx/version.go
+++ b/cmd/kubectx/version.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	version = "v0.0.0+unknown" // populated by goreleaser
+)
+
+// VersionOps describes printing version string.
+type VersionOp struct{}
+
+func (_ VersionOp) Run(stdout, _ io.Writer) error {
+	_, err := fmt.Fprintf(stdout, "%s\n", version)
+	return errors.Wrap(err, "write error")
+}

--- a/cmd/kubens/flags.go
+++ b/cmd/kubens/flags.go
@@ -45,6 +45,9 @@ func parseArgs(argv []string) Op {
 		if v == "--help" || v == "-h" {
 			return HelpOp{}
 		}
+		if v == "--version" || v == "-V" {
+			return VersionOp{}
+		}
 		if v == "--current" || v == "-c" {
 			return CurrentOp{}
 		}

--- a/cmd/kubens/help.go
+++ b/cmd/kubens/help.go
@@ -38,7 +38,8 @@ func printUsage(out io.Writer) error {
   %PROG% -                  : switch to the previous namespace in this context
   %PROG% -c, --current      : show the current namespace
   %PROG% -h,--help          : show this message
-`
+  %PROG% -V,--version       : show version`
+
 	// TODO this replace logic is duplicated between this and kubectx
 	help = strings.ReplaceAll(help, "%PROG%", selfName())
 

--- a/cmd/kubens/version.go
+++ b/cmd/kubens/version.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	version = "v0.0.0+unknown" // populated by goreleaser
+)
+
+// VersionOps describes printing version string.
+type VersionOp struct{}
+
+func (_ VersionOp) Run(stdout, _ io.Writer) error {
+	_, err := fmt.Fprintf(stdout, "%s\n", version)
+	return errors.Wrap(err, "write error")
+}


### PR DESCRIPTION
Uses goreleaser to pass ldflags.
Closes #125 
Closes #279.
