### PR TITLE
stop using XDG_CACHE_HOME as home directory

### DIFF
--- a/internal/cmdutil/util.go
+++ b/internal/cmdutil/util.go
@@ -21,9 +21,6 @@ import (
 )
 
 func HomeDir() string {
-	if v := os.Getenv("XDG_CACHE_HOME"); v != "" {
-		return v
-	}
 	home := os.Getenv("HOME")
 	if home == "" {
 		home = os.Getenv("USERPROFILE") // windows

--- a/internal/cmdutil/util_test.go
+++ b/internal/cmdutil/util_test.go
@@ -28,12 +28,12 @@ func Test_homeDir(t *testing.T) {
 		want string
 	}{
 		{
-			name: "XDG_CACHE_HOME precedence",
+			name: "don't use XDG_CACHE_HOME as homedir",
 			envs: []env{
 				{"XDG_CACHE_HOME", "xdg"},
 				{"HOME", "home"},
 			},
-			want: "xdg",
+			want: "home",
 		},
 		{
 			name: "HOME over USERPROFILE",
@@ -46,7 +46,6 @@ func Test_homeDir(t *testing.T) {
 		{
 			name: "only USERPROFILE available",
 			envs: []env{
-				{"XDG_CACHE_HOME", ""},
 				{"HOME", ""},
 				{"USERPROFILE", "up"},
 			},
@@ -55,7 +54,6 @@ func Test_homeDir(t *testing.T) {
 		{
 			name: "none available",
 			envs: []env{
-				{"XDG_CACHE_HOME", ""},
 				{"HOME", ""},
 				{"USERPROFILE", ""},
 			},

--- a/test/common.bash
+++ b/test/common.bash
@@ -2,13 +2,15 @@
 
 # bats setup function
 setup() {
-  export XDG_CACHE_HOME="$(mktemp -d)"
-  export KUBECONFIG="${XDG_CACHE_HOME}/config"
+  TEMP_HOME="$(mktemp -d)"
+  export TEMP_HOME
+  export HOME=$TEMP_HOME
+  export KUBECONFIG="${TEMP_HOME}/config"
 }
 
 # bats teardown function
 teardown() {
-  rm -rf "$XDG_CACHE_HOME"
+  rm -rf "$TEMP_HOME"
 }
 
 use_config() {


### PR DESCRIPTION
XDG_CACHE_HOME is not a substitute for $HOME, see [1].

[1]: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html