### PR TITLE
386, s390x and risv64 CPU archs for releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,8 +33,6 @@ builds:
     - arm
     - arm64
     - ppc64le
-    - s390x
-    - riscv64
   goarm: [6, 7]
 - id: kubens
   main: ./cmd/kubens
@@ -51,8 +49,6 @@ builds:
     - arm
     - arm64
     - ppc64le
-    - s390x
-    - riscv64
   goarm: [6, 7]
 archives:
 - id: kubectx-archive

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,9 +29,12 @@ builds:
     - windows
   goarch:
     - amd64
+    - 386
     - arm
     - arm64
     - ppc64le
+    - s390x
+    - riscv64
   goarm: [6, 7]
 - id: kubens
   main: ./cmd/kubens
@@ -44,9 +47,12 @@ builds:
     - windows
   goarch:
     - amd64
+    - 386
     - arm
     - arm64
     - ppc64le
+    - s390x
+    - riscv64
   goarm: [6, 7]
 archives:
 - id: kubectx-archive


### PR DESCRIPTION
- 386 can be actually useful, especially on (cheap) NAS with 32 bit non-ARM processors
- s390x is for the fun of it AFAIK
- riscv64 is really not that useful but could be in the future, and it's supported by goreleaser since January 2021 😉

Thanks!