### PR TITLE
Add interactive delete op

### DIFF
--- a/cmd/kubectx/flags.go
+++ b/cmd/kubectx/flags.go
@@ -42,7 +42,11 @@ func parseArgs(argv []string) Op {
 
 	if argv[0] == "-d" {
 		if len(argv) == 1 {
-			return UnsupportedOp{Err: fmt.Errorf("'-d' needs arguments")}
+			if cmdutil.IsInteractiveMode(os.Stdout) {
+				return InteractiveDeleteOp{SelfCmd: os.Args[0]}
+			} else {
+				return UnsupportedOp{Err: fmt.Errorf("'-d' needs arguments")}
+			}
 		}
 		return DeleteOp{Contexts: argv[1:]}
 	}


### PR DESCRIPTION
Addresses issue #303

Interactive menu if `fzf` is available for delete option on kubectx.

<details><summary><strong>Interactive selection of context for deletion</strong></summary>
<img src = "https://user-images.githubusercontent.com/13623913/124791680-ffbcf380-df6b-11eb-8c1e-80a14bbed76d.gif" width="700" />
</details>

---

*The rest of the behavior is intact.*

<details><summary><strong>Deleting current context</strong></summary>
<img src = "https://user-images.githubusercontent.com/13623913/124792882-27608b80-df6d-11eb-9931-799aa756fb22.gif" width="700" /> </details>


<details><summary><strong>Deleting context by name</strong></summary>
<img src = "https://user-images.githubusercontent.com/13623913/124793372-a3f36a00-df6d-11eb-881d-9e48e7d1aae8.gif" width="700" /> </details>
