### PR TITLE
Adding skim support

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,14 +231,19 @@ sudo ln -s /opt/kubectx/kubens /usr/local/bin/kubens
 ### Interactive mode
 
 If you want `kubectx` and `kubens` commands to present you an interactive menu
-with fuzzy searching, you just need to [install
+with fuzzy searching, you can do in either of two ways 
+
+* [Install
 `fzf`](https://github.com/junegunn/fzf) in your PATH.
+ * OR [Install `sk`](https://github.com/lotabout/skim) in your PATH and set environment variable `PICKER` to `sk`
 
 ![kubectx interactive search with fzf](img/kubectx-interactive.gif)
 
 If you have `fzf` installed, but want to opt out of using this feature, set the environment variable `KUBECTX_IGNORE_FZF=1`.
 
-If you want to keep `fzf` interactive mode but need the default behavior of the command, you can do it using Unix composability:
+> Note: skim support in kubectx and kubens is only in go binary.
+
+If you want to keep `fzf` or `sk` interactive mode but need the default behavior of the command, you can do it using Unix composability:
 ```
 kubectx | cat
 ```

--- a/cmd/kubectx/flags.go
+++ b/cmd/kubectx/flags.go
@@ -19,8 +19,6 @@ import (
 	"io"
 	"os"
 	"strings"
-
-	"github.com/ahmetb/kubectx/internal/cmdutil"
 )
 
 // UnsupportedOp indicates an unsupported flag.
@@ -34,7 +32,7 @@ func (op UnsupportedOp) Run(_, _ io.Writer) error {
 // and decides which operation should be taken.
 func parseArgs(argv []string) Op {
 	if len(argv) == 0 {
-		if cmdutil.IsInteractiveMode(os.Stdout) {
+		if true { //cmdutil.IsInteractiveMode(os.Stdout) {
 			return InteractiveSwitchOp{SelfCmd: os.Args[0]}
 		}
 		return ListOp{}
@@ -42,7 +40,7 @@ func parseArgs(argv []string) Op {
 
 	if argv[0] == "-d" {
 		if len(argv) == 1 {
-			if cmdutil.IsInteractiveMode(os.Stdout) {
+			if true { //cmdutil.IsInteractiveMode(os.Stdout) {
 				return InteractiveDeleteOp{SelfCmd: os.Args[0]}
 			} else {
 				return UnsupportedOp{Err: fmt.Errorf("'-d' needs arguments")}

--- a/cmd/kubectx/flags.go
+++ b/cmd/kubectx/flags.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"os"
 	"strings"
+
+	"github.com/ahmetb/kubectx/internal/cmdutil"
 )
 
 // UnsupportedOp indicates an unsupported flag.
@@ -32,16 +34,18 @@ func (op UnsupportedOp) Run(_, _ io.Writer) error {
 // and decides which operation should be taken.
 func parseArgs(argv []string) Op {
 	if len(argv) == 0 {
-		if true { //cmdutil.IsInteractiveMode(os.Stdout) {
-			return InteractiveSwitchOp{SelfCmd: os.Args[0]}
+		picker, interactive := cmdutil.IsInteractiveMode(os.Stdout)
+		if interactive {
+			return InteractiveSwitchOp{SelfCmd: os.Args[0], Picker: picker}
 		}
 		return ListOp{}
 	}
 
 	if argv[0] == "-d" {
 		if len(argv) == 1 {
-			if true { //cmdutil.IsInteractiveMode(os.Stdout) {
-				return InteractiveDeleteOp{SelfCmd: os.Args[0]}
+			picker, interactive := cmdutil.IsInteractiveMode(os.Stdout)
+			if interactive {
+				return InteractiveDeleteOp{SelfCmd: os.Args[0], Picker: picker}
 			} else {
 				return UnsupportedOp{Err: fmt.Errorf("'-d' needs arguments")}
 			}

--- a/cmd/kubens/flags.go
+++ b/cmd/kubens/flags.go
@@ -34,8 +34,9 @@ func (op UnsupportedOp) Run(_, _ io.Writer) error {
 // and decides which operation should be taken.
 func parseArgs(argv []string) Op {
 	if len(argv) == 0 {
-		if cmdutil.IsInteractiveMode(os.Stdout) {
-			return InteractiveSwitchOp{SelfCmd: os.Args[0]}
+		picker, interactive := cmdutil.IsInteractiveMode(os.Stdout)
+		if interactive {
+			return InteractiveSwitchOp{SelfCmd: os.Args[0], Picker: picker}
 		}
 		return ListOp{}
 	}

--- a/cmd/kubens/help.go
+++ b/cmd/kubens/help.go
@@ -27,7 +27,7 @@ import (
 // HelpOp describes printing help.
 type HelpOp struct{}
 
-func (_ HelpOp) Run(stdout, _ io.Writer) error {
+func (HelpOp) Run(stdout, _ io.Writer) error {
 	return printUsage(stdout)
 }
 

--- a/cmd/kubens/version.go
+++ b/cmd/kubens/version.go
@@ -14,7 +14,7 @@ var (
 // VersionOps describes printing version string.
 type VersionOp struct{}
 
-func (_ VersionOp) Run(stdout, _ io.Writer) error {
+func (VersionOp) Run(stdout, _ io.Writer) error {
 	_, err := fmt.Fprintf(stdout, "%s\n", version)
 	return errors.Wrap(err, "write error")
 }

--- a/internal/cmdutil/interactive_test.go
+++ b/internal/cmdutil/interactive_test.go
@@ -1,0 +1,54 @@
+package cmdutil
+
+import (
+	"testing"
+
+	"github.com/ahmetb/kubectx/internal/testutil"
+)
+
+func Test_fuzzyPicker(t *testing.T) {
+	type env struct{ k, v string }
+
+	cases := []struct {
+		name string
+		envs []env
+		want string
+	}{
+		{
+			name: "PICKER is fzf",
+			envs: []env{
+				{"PICKER", "fzf"},
+			},
+			want: "fzf",
+		}, {
+			name: "PICKER is sk",
+			envs: []env{
+				{"PICKER", "sk"},
+			},
+			want: "sk",
+		}, {
+			name: "PICKER is not set",
+			envs: []env{},
+			want: "fzf",
+		}, {
+			name: "PICKER is other than fzf and sk",
+			envs: []env{{"PICKER", "other-fuzzer"}},
+			want: "fzf",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(tt *testing.T) {
+			var unsets []func()
+			for _, e := range c.envs {
+				unsets = append(unsets, testutil.WithEnvVar(e.k, e.v))
+			}
+			got := fuzzyPicker()
+			if got != c.want {
+				t.Errorf("want: %s, got: %s", c.want, got)
+			}
+			for _, u := range unsets {
+				u()
+			}
+		})
+	}
+}

--- a/internal/env/constants.go
+++ b/internal/env/constants.go
@@ -29,4 +29,12 @@ const (
 
 	// EnvDebug describes the internal environment variable for more verbose logging.
 	EnvDebug = `DEBUG`
+
+	// EnvPicker describes the environment variable for fuzzy support, It can value
+	// fzf or sk. If this is not set then fzf is taken as default picker.
+	EnvPicker = `PICKER`
+
+	// EnvSKIgnore describes the environment variable to disable interactive context
+	// selection when skim is installed
+	EnvSKIgnore = `KUBECTX_IGNORE_SK`
 )


### PR DESCRIPTION
[See the Feature request here](https://github.com/ahmetb/kubectx/issues/305)

Added skim support in kubens and kubectx go version.

Added environment variable **PICKER** which will contain value **sk** or **fzf**, if PICKER is not set or anything else is set other than sk and fzf, then it will by default pick fzf.

Created a func InteractiveSearch in interactive.go which will be called for fuzzy search and renamed fzf.go to fuzzy.go since it is now more generic.