### PR TITLE
Wrap context names in single quotes to prevent completion script to fail

### DIFF
--- a/completion/kubectx.zsh
+++ b/completion/kubectx.zsh
@@ -3,7 +3,9 @@
 local KUBECTX="${HOME}/.kube/kubectx"
 PREV=""
 
-local all_contexts="$(kubectl config get-contexts --output='name')"
+local context_array=("${(@f)$(kubectl config get-contexts --output='name')}")
+local all_contexts=(\'${^context_array}\')
+
 if [ -f "$KUBECTX" ]; then
     # show '-' only if there's a saved previous context
     local PREV=$(cat "${KUBECTX}")


### PR DESCRIPTION
Add single quotes to the list of context names passed to zsh _arguments. 

Now completion behaves like this:

```
> kubectx "test(1)"=.
Context "test" renamed to "test(1)".

> kubectx <Tab>
-     mycontext\(1\)
```
Fixes #314