### PR TITLE
feat: pre-select stuff with fzf

### DIFF
--- a/cmd/kubectx/flags.go
+++ b/cmd/kubectx/flags.go
@@ -65,13 +65,20 @@ func parseArgs(argv []string) Op {
 		if v == "--unset" || v == "-u" {
 			return UnsetOp{}
 		}
-
+		if argv[0] == "-" {
+			return SwitchOp{Target: "-"}
+		}
 		if new, old, ok := parseRenameSyntax(v); ok {
 			return RenameOp{New: new, Old: old}
 		}
-
 		if strings.HasPrefix(v, "-") && v != "-" {
 			return UnsupportedOp{Err: fmt.Errorf("unsupported option '%s'", v)}
+		}
+		if cmdutil.IsInteractiveMode(os.Stdout) {
+			return InteractiveSwitchOp{
+				SelfCmd: os.Args[0],
+				Target:  argv[0],
+			}
 		}
 		return SwitchOp{Target: argv[0]}
 	}

--- a/cmd/kubectx/flags.go
+++ b/cmd/kubectx/flags.go
@@ -65,19 +65,19 @@ func parseArgs(argv []string) Op {
 		if v == "--unset" || v == "-u" {
 			return UnsetOp{}
 		}
-		if argv[0] == "-" {
+		if v == "-" {
 			return SwitchOp{Target: "-"}
 		}
 		if new, old, ok := parseRenameSyntax(v); ok {
 			return RenameOp{New: new, Old: old}
 		}
-		if strings.HasPrefix(v, "-") && v != "-" {
+		if strings.HasPrefix(v, "-") {
 			return UnsupportedOp{Err: fmt.Errorf("unsupported option '%s'", v)}
 		}
 		if cmdutil.IsInteractiveMode(os.Stdout) {
 			return InteractiveSwitchOp{
 				SelfCmd: os.Args[0],
-				Target:  argv[0],
+				Query:   argv[0],
 			}
 		}
 		return SwitchOp{Target: argv[0]}

--- a/cmd/kubectx/fzf.go
+++ b/cmd/kubectx/fzf.go
@@ -32,7 +32,7 @@ import (
 
 type InteractiveSwitchOp struct {
 	SelfCmd string
-	Target  string
+	Query   string
 }
 
 type InteractiveDeleteOp struct {
@@ -51,7 +51,7 @@ func (op InteractiveSwitchOp) Run(_, stderr io.Writer) error {
 	}
 	kc.Close()
 
-	cmd := exec.Command("fzf", "--ansi", "--no-preview", "-q", op.Target, "-1")
+	cmd := exec.Command("fzf", "--ansi", "--no-preview", "--query", op.Query, "--select-1")
 	var out bytes.Buffer
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = stderr

--- a/cmd/kubectx/fzf.go
+++ b/cmd/kubectx/fzf.go
@@ -32,6 +32,7 @@ import (
 
 type InteractiveSwitchOp struct {
 	SelfCmd string
+	Target  string
 }
 
 type InteractiveDeleteOp struct {
@@ -50,7 +51,7 @@ func (op InteractiveSwitchOp) Run(_, stderr io.Writer) error {
 	}
 	kc.Close()
 
-	cmd := exec.Command("fzf", "--ansi", "--no-preview")
+	cmd := exec.Command("fzf", "--ansi", "--no-preview", "-q", op.Target, "-1")
 	var out bytes.Buffer
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = stderr

--- a/cmd/kubens/flags.go
+++ b/cmd/kubens/flags.go
@@ -51,8 +51,17 @@ func parseArgs(argv []string) Op {
 		if v == "--current" || v == "-c" {
 			return CurrentOp{}
 		}
+		if argv[0] == "-" {
+			return SwitchOp{Target: "-"}
+		}
 		if strings.HasPrefix(v, "-") && v != "-" {
 			return UnsupportedOp{Err: fmt.Errorf("unsupported option '%s'", v)}
+		}
+		if cmdutil.IsInteractiveMode(os.Stdout) {
+			return InteractiveSwitchOp{
+				SelfCmd: os.Args[0],
+				Target:  argv[0],
+			}
 		}
 		return SwitchOp{Target: argv[0]}
 	}

--- a/cmd/kubens/flags.go
+++ b/cmd/kubens/flags.go
@@ -51,16 +51,16 @@ func parseArgs(argv []string) Op {
 		if v == "--current" || v == "-c" {
 			return CurrentOp{}
 		}
-		if argv[0] == "-" {
+		if v == "-" {
 			return SwitchOp{Target: "-"}
 		}
-		if strings.HasPrefix(v, "-") && v != "-" {
+		if strings.HasPrefix(v, "-") {
 			return UnsupportedOp{Err: fmt.Errorf("unsupported option '%s'", v)}
 		}
 		if cmdutil.IsInteractiveMode(os.Stdout) {
 			return InteractiveSwitchOp{
 				SelfCmd: os.Args[0],
-				Target:  argv[0],
+				Query:   argv[0],
 			}
 		}
 		return SwitchOp{Target: argv[0]}

--- a/cmd/kubens/fzf.go
+++ b/cmd/kubens/fzf.go
@@ -32,7 +32,7 @@ import (
 
 type InteractiveSwitchOp struct {
 	SelfCmd string
-	Target  string
+	Query   string
 }
 
 // TODO(ahmetb) This method is heavily repetitive vs kubectx/fzf.go.
@@ -48,7 +48,7 @@ func (op InteractiveSwitchOp) Run(_, stderr io.Writer) error {
 	}
 	defer kc.Close()
 
-	cmd := exec.Command("fzf", "--ansi", "--no-preview", "-q", op.Target, "-1")
+	cmd := exec.Command("fzf", "--ansi", "--no-preview", "--query", op.Query, "--select-1")
 	var out bytes.Buffer
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = stderr

--- a/cmd/kubens/fzf.go
+++ b/cmd/kubens/fzf.go
@@ -32,6 +32,7 @@ import (
 
 type InteractiveSwitchOp struct {
 	SelfCmd string
+	Target  string
 }
 
 // TODO(ahmetb) This method is heavily repetitive vs kubectx/fzf.go.
@@ -47,7 +48,7 @@ func (op InteractiveSwitchOp) Run(_, stderr io.Writer) error {
 	}
 	defer kc.Close()
 
-	cmd := exec.Command("fzf", "--ansi", "--no-preview")
+	cmd := exec.Command("fzf", "--ansi", "--no-preview", "-q", op.Target, "-1")
 	var out bytes.Buffer
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = stderr


### PR DESCRIPTION
as discussed on twitter (https://twitter.com/caarlos0/status/1443410098471194625), PR adding this feature.

- if input is `-`, switch right away
- if input is interactive, go through fzf with input as query
- if not interactive, switch as before

implemented on both kubectx and kubens.

PS: would you also be interested in having a homebrew tap that uses the go versions? Right now I'm maintaining my own, but I can port the config here if you create a `homebrew-tap` repository :) 

Cheers!