### PR TITLE
Added hability to switch to a context using a partial name

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -108,7 +108,11 @@ save_context() {
 }
 
 switch_context() {
-  $KUBECTL config use-context "${1}"
+  if [ "$(get_contexts | grep -c "${1}")" -eq 1 ]; then
+    $KUBECTL config use-context "$(get_contexts | grep "${1}")"
+  else
+    $KUBECTL config use-context "${1}"
+  fi
 }
 
 choose_context_interactive() {


### PR DESCRIPTION
This PR is to be able to switch to the context if only one matches. This is intended for EKS clusters where the default context name is the ARN (arn:aws:eks:REGION:ACCOUNTNUMBER:cluster/CLUSTERNAME) which is quite long but includes the cluster name