### PR TITLE
Support deleting multiple contexts separated by spaces

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -19,7 +19,7 @@
 [[ -n $DEBUG ]] && set -x
 
 set -eou pipefail
-IFS=$'\n\t'
+IFS=$'\n\t '
 
 SELF_CMD="$0"
 


### PR DESCRIPTION
In the current implementation, `kubectx -d ctx1 ctx2` doesn't work because it's interpreted as `'ctx1 ctx2'`.