### PR TITLE
Hello :)

### DIFF
--- a/cmd/kubectx/state.go
+++ b/cmd/kubectx/state.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"cmp"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -25,7 +26,7 @@ import (
 )
 
 func kubectxPrevCtxFile() (string, error) {
-	home := cmdutil.HomeDir()
+	home := cmp.Or(os.Getenv("KUBECTX_DIR"), cmdutil.HomeDir())
 	if home == "" {
 		return "", errors.New("HOME or USERPROFILE environment variable not set")
 	}

--- a/cmd/kubens/statefile.go
+++ b/cmd/kubens/statefile.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -25,7 +26,7 @@ import (
 	"github.com/ahmetb/kubectx/internal/cmdutil"
 )
 
-var defaultDir = filepath.Join(cmdutil.HomeDir(), ".kube", "kubens")
+var defaultDir = filepath.Join(cmp.Or(os.Getenv("KUBECTX_DIR"), cmdutil.HomeDir()), ".kube", "kubens")
 
 type NSFile struct {
 	dir string

--- a/internal/kubeconfig/kubeconfigloader.go
+++ b/internal/kubeconfig/kubeconfigloader.go
@@ -15,6 +15,7 @@
 package kubeconfig
 
 import (
+	"cmp"
 	"github.com/ahmetb/kubectx/internal/cmdutil"
 	"os"
 	"path/filepath"
@@ -68,7 +69,7 @@ func kubeconfigPath() (string, error) {
 	}
 
 	// default path
-	home := cmdutil.HomeDir()
+	home := cmp.Or(os.Getenv("KUBECTX_DIR"), cmdutil.HomeDir())
 	if home == "" {
 		return "", errors.New("HOME or USERPROFILE environment variable not set")
 	}

--- a/kubectx
+++ b/kubectx
@@ -23,7 +23,8 @@ IFS=$'\n\t'
 
 SELF_CMD="$0"
 
-KUBECTX="${XDG_CACHE_HOME:-$HOME/.kube}/kubectx"
+[ -v KUBECTX_DIR ] && KUBECTX_DIR=${KUBECTX_DIR}/.kube/kubectx
+KUBECTX="${KUBECTX_DIR:-${XDG_CACHE_HOME:-$HOME/.kube}/kubectx}"
 
 usage() {
   local SELF

--- a/kubens
+++ b/kubens
@@ -23,7 +23,8 @@ IFS=$'\n\t'
 
 SELF_CMD="$0"
 
-KUBENS_DIR="${XDG_CACHE_HOME:-$HOME/.kube}/kubens"
+[ -v KUBENS_DIR ] && KUBENS_DIR=${KUBENS_DIR}/.kube/kubectx
+KUBENS_DIR="${KUBENS_DIR:-${XDG_CACHE_HOME:-$HOME/.kube}/kubectx}"
 
 usage() {
   local SELF


### PR DESCRIPTION
It's my first PR to an Go project here, so be kind to me :)

It's possible to set KUBECTX_DIR and KUBENS_DIR as an environemnt variable.

Example:

> KUBECTX_DIR="/foo/bar"

will result in /foo/bar/.kube/kubectx

When KUBECTX_DIR is not set, kubectx and kubens fall back to the default behavior.

issue: #402