### PR TITLE
Add Flox as an installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ this new Go implementation by downloading the binaries from the [**Releases page
 - [with Chocolatey (Windows)](#windows-installation-using-chocolatey)
 - [Windows Installation (using Scoop)](#windows-installation-using-scoop)
 - [with winget (Windows)](#windows-installation-using-winget)
+- [with Flox (macOS & Linux & Windows WSL)](#flox)
 - [manually (macOS & Linux)](#manual-installation-macos-and-linux)
 
 If you like to add context/namespace information to your shell prompt (`$PS1`),
@@ -172,6 +173,13 @@ Available as packages on [winget](https://learn.microsoft.com/en-us/windows/pack
 ```pwsh
 winget install --id ahmetb.kubectx
 winget install --id ahmetb.kubens
+```
+
+### Flox
+
+Available as packages on [Flox](https://flox.dev)
+```pwsh
+flox install kubectx
 ```
 
 ### Manual Installation (macOS and Linux)


### PR DESCRIPTION
`kubectx` is available and working in Flox.

I did a minimal test as follows.

```console
$ flox init
✨ Created environment 'tmp.OzONlp90TB' (aarch64-darwin)

Next:
  $ flox search <package>    <- Search for a package
  $ flox install <package>   <- Install a package into an environment
  $ flox activate            <- Enter the environment
  $ flox edit                <- Add environment variables and shell hooks

$ flox search kubectx
kubectx                     Fast way to switch between clusters and namespaces in kubectl!
emacsPackages.kubectx-mode  <no description provided>
kubeswitch                          The kubectx for operators

Use 'flox show <package>' to see available versions

$ flox install kubectx
✅ 'kubectx' installed to environment 'tmp.OzONlp90TB'
$ flox activate -- kubectx --version
0.9.5
```