### PR TITLE
Feat: add a flag to allow prefixing a query in interactive mode

### DIFF
--- a/cmd/kubectx/flags.go
+++ b/cmd/kubectx/flags.go
@@ -45,7 +45,7 @@ func parseArgs(argv []string) Op {
 			if len(argv) > 1 {
 				return InteractiveSwitchOp{SelfCmd: os.Args[0], Query: argv[1]}
 			} else {
-				return UnsupportedOp{Err: fmt.Errorf("'-q' needs arguments")}
+				return UnsupportedOp{Err: fmt.Errorf("'-q' needs an argument")}
 			}
 		} else {
 			return UnsupportedOp{Err: fmt.Errorf("'-q' only works in interactive mode")}

--- a/cmd/kubectx/flags.go
+++ b/cmd/kubectx/flags.go
@@ -40,6 +40,17 @@ func parseArgs(argv []string) Op {
 		return ListOp{}
 	}
 
+	if argv[0] == "-q" {
+		if cmdutil.IsInteractiveMode(os.Stdout) {
+			if len(argv) > 1 {
+				return InteractiveSwitchOp{SelfCmd: os.Args[0], Query: argv[1]}
+			} else {
+				return UnsupportedOp{Err: fmt.Errorf("'-q' needs arguments")}
+			}
+		} else {
+			return UnsupportedOp{Err: fmt.Errorf("'-q' only works in interactive mode")}
+		}
+	}
 	if argv[0] == "-d" {
 		if len(argv) == 1 {
 			if cmdutil.IsInteractiveMode(os.Stdout) {

--- a/cmd/kubectx/flags_test.go
+++ b/cmd/kubectx/flags_test.go
@@ -78,6 +78,10 @@ func Test_parseArgs_new(t *testing.T) {
 		{name: "too many args",
 			args: []string{"a", "b", "c"},
 			want: UnsupportedOp{Err: fmt.Errorf("too many arguments")}},
+		{name: "missing query",
+			args: []string{"-q"},
+			want: UnsupportedOp{Err: fmt.Errorf("'-q' only works in interactive mode")},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/kubectx/help.go
+++ b/cmd/kubectx/help.go
@@ -41,6 +41,7 @@ func printUsage(out io.Writer) error {
   %PROG% <NEW_NAME>=.          : rename current-context to <NEW_NAME>
   %PROG% -u, --unset           : unset the current context
   %PROG% -d <NAME> [<NAME...>] : delete context <NAME> ('.' for current-context)
+  %PROG% -q <QUERY>            : start the finder with the given query
   %SPAC%                         (this command won't delete the user/cluster entry
   %SPAC%                          referenced by the context entry)
   %PROG% -h,--help             : show this message


### PR DESCRIPTION
### Behaviour 
```sh
$ kubectx -q prod
```
will output: 
<img width="378" alt="Screenshot 2024-09-22 at 18 16 59" src="https://github.com/user-attachments/assets/a33b952e-b71b-4cdd-b1b7-11d8c82d8d47">
