### PR TITLE
docs: add description and legacy note to bash --help output

### DIFF
--- a/kubectx
+++ b/kubectx
@@ -33,6 +33,8 @@ usage() {
   fi
 
   cat <<EOF
+Manage and switch between kubectl contexts.
+
 USAGE:
   $SELF                       : list the contexts
   $SELF <NAME>                : switch to context <NAME>
@@ -46,6 +48,8 @@ USAGE:
   $SELF -u, --unset           : unset the current context
 
   $SELF -h,--help             : show this message
+
+  (This executable is the legacy bash-based implementation, consider upgrading to Go-based implementation.)
 EOF
 }
 

--- a/kubens
+++ b/kubens
@@ -33,12 +33,16 @@ usage() {
   fi
 
   cat <<EOF
+Switch between Kubernetes namespaces.
+
 USAGE:
   $SELF                    : list the namespaces in the current context
   $SELF <NAME>             : change the active namespace of current context
   $SELF -                  : switch to the previous namespace in this context
   $SELF -c, --current      : show the current namespace
   $SELF -h,--help          : show this message
+
+  (This executable is the legacy bash-based implementation, consider upgrading to Go-based implementation.)
 EOF
 }
 


### PR DESCRIPTION
Add a one-line description and a note encouraging users to upgrade to the Go-based implementation in the bash help messages.