### PR TITLE
fix(ci): upgrade actions/cache from v2 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,12 +31,12 @@ jobs:
         echo "::set-output name=go-build::$(go env GOCACHE)"
         echo "::set-output name=go-mod::$(go env GOMODCACHE)"
     - name: Go Build Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-build }}
         key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
     - name: Go Mod Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.go-cache-paths.outputs.go-mod }}
         key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
## Summary
- Upgrade `actions/cache` from v2 to v4 in the CI workflow
- v2 has been deprecated by GitHub and now causes automatic failures

## Test plan
- [ ] CI workflow runs successfully with the updated cache action

🤖 Generated with [Claude Code](https://claude.com/claude-code)