### PR TITLE
chore: add dependabot config and auto-merge workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: chore
+    include: scope
+
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: chore
+    include: scope
+  groups:
+    kubernetes:
+      patterns:
+        - "k8s.io/*"

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,24 @@
+name: Dependabot
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+    - name: Dependabot metadata
+      id: metadata
+      uses: dependabot/fetch-metadata@v2
+
+    - name: Enable auto-merge for Dependabot PRs
+      if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
+      run: gh pr merge --auto --merge "$PR_URL"
+      env:
+        PR_URL: ${{ github.event.pull_request.html_url }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for weekly dependency updates (github-actions and gomod)
- Add `.github/workflows/dependabot.yml` to auto-merge non-major Dependabot PRs
- Group k8s.io packages together for cleaner updates

## Test plan
- [ ] Verify dependabot starts creating PRs after merge
- [ ] Verify auto-merge triggers on dependabot PRs for minor/patch updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)