### PR TITLE
ci: warn PRs modifying frozen bash scripts

### DIFF
--- a/.github/workflows/bash-frozen.yml
+++ b/.github/workflows/bash-frozen.yml
@@ -1,0 +1,35 @@
+name: Bash scripts frozen
+
+on:
+  pull_request:
+    paths:
+      - 'kubectx'
+      - 'kubens'
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment on PR if author is not ahmetb
+        if: github.event.pull_request.user.login != 'ahmetb'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = [
+              '> [!WARNING]',
+              '> **This PR will not be merged.**',
+              '>',
+              '> The bash implementation of `kubectx` and `kubens` is **frozen** and is provided only for convenience.',
+              '> We are not accepting any improvements to the bash scripts.',
+              '>',
+              '> Please propose your improvements to the **Go implementation** instead.',
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that comments on PRs modifying the root `kubectx` or `kubens` bash scripts
- The comment uses a `[!WARNING]` alert to inform contributors that bash implementations are frozen and to propose changes to the Go implementation instead
- Skips the comment if the PR author is `ahmetb`

## Test plan
- [ ] Open a test PR that modifies `kubectx` or `kubens` from a non-`ahmetb` account and verify the warning comment appears
- [ ] Verify PRs from `ahmetb` do not trigger the comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)