### PR TITLE
chore: update goreleaser config and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v4
     - run: git fetch --tags
     - name: Setup Go
       uses: actions/setup-go@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # This is an example goreleaser.yaml file with some sane defaults.
-# Make sure to check the documentation at http://goreleaser.com
+# Make sure to check the documentation at https://goreleaser.com
 
 version: 2
 before:
@@ -69,11 +69,11 @@ archives:
       {{- else -}}v{{- . -}}
       {{- end -}}
     {{- end -}}
-  builds:
+  ids:
     - kubectx
   format_overrides:
     - goos: windows
-      format: zip
+      formats: [zip]
   files: ["LICENSE"]
 - id: kubens-archive
   name_template: |-
@@ -89,11 +89,11 @@ archives:
       {{- else -}}v{{- . -}}
       {{- end -}}
     {{- end -}}
-  builds:
+  ids:
     - kubens
   format_overrides:
     - goos: windows
-      format: zip
+      formats: [zip]
   files: ["LICENSE"]
 checksum:
   name_template: "checksums.txt"
@@ -111,7 +111,7 @@ snapcrafts:
       kubens is a tool to switch between Kubernetes namespaces (and configure them for kubectl) easily.
     grade: stable
     confinement: classic
-    base: core20
+    base: core24
     apps:
       kubectx:
         command: kubectx


### PR DESCRIPTION
## Summary
- Pin `actions/checkout` to `@v4` instead of `@master` for supply-chain safety and reproducibility
- Rename deprecated `builds` → `ids` in archive sections (goreleaser v2 convention)
- Rename deprecated `format` → `formats` (plural, list) in `format_overrides` (since goreleaser v2.6)
- Update Snapcraft base from `core20` (Ubuntu 20.04, EOL) to `core24` (Ubuntu 24.04 LTS)
- Fix comment URL from HTTP to HTTPS

## Test plan
- [ ] Verify `goreleaser check` passes on the updated config
- [ ] Confirm next tag-triggered release builds and publishes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)