### PR TITLE
feat: add XDG_CACHE_HOME support to Go implementations

### DIFF
--- a/cmd/kubectx/state.go
+++ b/cmd/kubectx/state.go
@@ -24,11 +24,11 @@ import (
 )
 
 func kubectxPrevCtxFile() (string, error) {
-	home := cmdutil.HomeDir()
-	if home == "" {
+	dir := cmdutil.CacheDir()
+	if dir == "" {
 		return "", errors.New("HOME or USERPROFILE environment variable not set")
 	}
-	return filepath.Join(home, ".kube", "kubectx"), nil
+	return filepath.Join(dir, "kubectx"), nil
 }
 
 // readLastContext returns the saved previous context

--- a/cmd/kubectx/state_test.go
+++ b/cmd/kubectx/state_test.go
@@ -73,8 +73,22 @@ func Test_writeLastContext(t *testing.T) {
 
 func Test_kubectxFilePath(t *testing.T) {
 	t.Setenv("HOME", filepath.FromSlash("/foo/bar"))
+	t.Setenv("XDG_CACHE_HOME", "")
 
 	expected := filepath.Join(filepath.FromSlash("/foo/bar"), ".kube", "kubectx")
+	v, err := kubectxPrevCtxFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != expected {
+		t.Fatalf("expected=\"%s\" got=\"%s\"", expected, v)
+	}
+}
+
+func Test_kubectxFilePath_xdgCacheHome(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", filepath.FromSlash("/tmp/xdg-cache"))
+
+	expected := filepath.Join(filepath.FromSlash("/tmp/xdg-cache"), "kubectx")
 	v, err := kubectxPrevCtxFile()
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/kubens/statefile.go
+++ b/cmd/kubens/statefile.go
@@ -24,7 +24,7 @@ import (
 	"github.com/ahmetb/kubectx/internal/cmdutil"
 )
 
-var defaultDir = filepath.Join(cmdutil.HomeDir(), ".kube", "kubens")
+var defaultDir = filepath.Join(cmdutil.CacheDir(), "kubens")
 
 type NSFile struct {
 	dir string

--- a/internal/cmdutil/util.go
+++ b/internal/cmdutil/util.go
@@ -17,6 +17,7 @@ package cmdutil
 import (
 	"errors"
 	"os"
+	"path/filepath"
 )
 
 func HomeDir() string {
@@ -25,6 +26,19 @@ func HomeDir() string {
 		home = os.Getenv("USERPROFILE") // windows
 	}
 	return home
+}
+
+// CacheDir returns XDG_CACHE_HOME if set, otherwise $HOME/.kube,
+// matching the bash scripts' behavior: ${XDG_CACHE_HOME:-$HOME/.kube}.
+func CacheDir() string {
+	if xdg := os.Getenv("XDG_CACHE_HOME"); xdg != "" {
+		return xdg
+	}
+	home := HomeDir()
+	if home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".kube")
 }
 
 // IsNotFoundErr determines if the underlying error is os.IsNotExist.

--- a/internal/cmdutil/util_test.go
+++ b/internal/cmdutil/util_test.go
@@ -15,6 +15,7 @@
 package cmdutil
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/ahmetb/kubectx/internal/testutil"
@@ -77,4 +78,30 @@ func Test_homeDir(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCacheDir(t *testing.T) {
+	t.Run("XDG_CACHE_HOME set", func(t *testing.T) {
+		t.Setenv("XDG_CACHE_HOME", "/tmp/xdg-cache")
+		t.Setenv("HOME", "/home/user")
+		if got := CacheDir(); got != "/tmp/xdg-cache" {
+			t.Errorf("expected:%q got:%q", "/tmp/xdg-cache", got)
+		}
+	})
+	t.Run("XDG_CACHE_HOME unset, falls back to HOME/.kube", func(t *testing.T) {
+		t.Setenv("XDG_CACHE_HOME", "")
+		t.Setenv("HOME", "/home/user")
+		want := filepath.Join("/home/user", ".kube")
+		if got := CacheDir(); got != want {
+			t.Errorf("expected:%q got:%q", want, got)
+		}
+	})
+	t.Run("neither set", func(t *testing.T) {
+		t.Setenv("XDG_CACHE_HOME", "")
+		t.Setenv("HOME", "")
+		t.Setenv("USERPROFILE", "")
+		if got := CacheDir(); got != "" {
+			t.Errorf("expected:%q got:%q", "", got)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Adds a new CacheDir() function that respects the XDG_CACHE_HOME environment variable, matching the bash scripts' behavior. kubectx and kubens now prefer XDG_CACHE_HOME when set, falling back to $HOME/.kube otherwise.

## Testing Done

Added comprehensive tests covering XDG_CACHE_HOME set, unset, and missing home directory scenarios. All existing tests pass.