### PR TITLE
fix: skip fzf launch when no contexts exist

### DIFF
--- a/cmd/kubectx/fzf.go
+++ b/cmd/kubectx/fzf.go
@@ -52,6 +52,14 @@ func (op InteractiveSwitchOp) Run(_, stderr io.Writer) error {
 		return fmt.Errorf("kubeconfig error: %w", err)
 	}
 
+	ctxNames, err := kc.ContextNames()
+	if err != nil {
+		return fmt.Errorf("failed to get context names: %w", err)
+	}
+	if len(ctxNames) == 0 {
+		return errors.New("no contexts found in the kubeconfig file")
+	}
+
 	cmd := exec.Command("fzf", "--ansi", "--no-preview")
 	var out bytes.Buffer
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
## Summary
- Return an error early in `InteractiveSwitchOp` when the kubeconfig has no contexts, instead of launching fzf with an empty list
- Mirrors the existing guard already present in `InteractiveDeleteOp`

## Test plan
- [x] `go build` and `go vet` pass
- [ ] Run `kubectx` with an empty kubeconfig to verify the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)