### PR TITLE
fix: skip fzf launch in kubens when no contexts exist in kubeconfig

### DIFF
--- a/cmd/kubens/fzf.go
+++ b/cmd/kubens/fzf.go
@@ -46,6 +46,14 @@ func (op InteractiveSwitchOp) Run(_, stderr io.Writer) error {
 		return fmt.Errorf("kubeconfig error: %w", err)
 	}
 
+	ctxNames, err := kc.ContextNames()
+	if err != nil {
+		return fmt.Errorf("failed to get context names: %w", err)
+	}
+	if len(ctxNames) == 0 {
+		return errors.New("no contexts found in the kubeconfig file")
+	}
+
 	cmd := exec.Command("fzf", "--ansi", "--no-preview")
 	var out bytes.Buffer
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
## Summary
- Adds the same empty-context check to `kubens` fzf mode that `kubectx` already has (added in #480)
- When kubeconfig has no contexts, kubens now returns `"no contexts found in the kubeconfig file"` instead of launching fzf which fails with `[Command failed: kubens]`

## Test plan
- [x] `go build` compiles successfully
- [x] `go test ./cmd/kubens/...` passes
- [ ] Manual: run `kubens` with an empty kubeconfig and fzf installed — should show error message instead of launching fzf

🤖 Generated with [Claude Code](https://claude.com/claude-code)