### PR TITLE
Fix relative path resolution in exec credential plugins

### DIFF
--- a/cmd/kubens/list.go
+++ b/cmd/kubens/list.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/ahmetb/kubectx/internal/kubeconfig"
@@ -102,11 +103,31 @@ func queryNamespaces(kc *kubeconfig.Kubeconfig) ([]string, error) {
 }
 
 func newKubernetesClientSet(kc *kubeconfig.Kubeconfig) (*kubernetes.Clientset, error) {
-	b, err := kc.Bytes()
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert in-memory kubeconfig to yaml: %w", err)
+	var cfg *rest.Config
+	var err error
+
+	if paths := kc.ConfigPaths(); len(paths) > 0 {
+		// Load from file paths so that client-go resolves relative paths
+		// (e.g. in exec credential plugins) relative to the kubeconfig directory.
+		//
+		// TODO: This re-reads and re-parses the kubeconfig files from disk via
+		// client-go, duplicating work already done by our kyaml-based loader.
+		// A better approach would be to extract the current context/cluster/user
+		// entries from the already-parsed multi-file kubeconfig and normalize
+		// relative paths in memory based on which file each entry was read from.
+		cfg, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{Precedence: paths},
+			&clientcmd.ConfigOverrides{},
+		).ClientConfig()
+	} else {
+		// Fallback for in-memory configs (e.g. tests).
+		var b []byte
+		b, err = kc.Bytes()
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert in-memory kubeconfig to yaml: %w", err)
+		}
+		cfg, err = clientcmd.RESTConfigFromKubeConfig(b)
 	}
-	cfg, err := clientcmd.RESTConfigFromKubeConfig(b)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize config: %w", err)
 	}

--- a/internal/kubeconfig/kubeconfig.go
+++ b/internal/kubeconfig/kubeconfig.go
@@ -29,12 +29,20 @@ type ReadWriteResetCloser interface {
 	Reset() error
 }
 
+// PathHinter is optionally implemented by ReadWriteResetCloser to indicate
+// the file path of the underlying kubeconfig file. This is used to resolve
+// relative paths (e.g. in exec credential plugins) when building a REST client.
+type PathHinter interface {
+	Path() string
+}
+
 type Loader interface {
 	Load() ([]ReadWriteResetCloser, error)
 }
 
 type fileEntry struct {
 	f      ReadWriteResetCloser
+	path   string
 	config *yaml.RNode
 }
 
@@ -83,9 +91,25 @@ func (k *Kubeconfig) Parse() error {
 			}
 			return fmt.Errorf("kubeconfig file %d is not a map document", i)
 		}
-		k.files = append(k.files, fileEntry{f: f, config: rn})
+		var p string
+		if ph, ok := f.(PathHinter); ok {
+			p = ph.Path()
+		}
+		k.files = append(k.files, fileEntry{f: f, path: p, config: rn})
 	}
 	return nil
+}
+
+// ConfigPaths returns the file paths of all loaded kubeconfig files.
+// Returns nil if the kubeconfig was not loaded from files (e.g. in tests).
+func (k *Kubeconfig) ConfigPaths() []string {
+	var paths []string
+	for _, fe := range k.files {
+		if fe.path != "" {
+			paths = append(paths, fe.path)
+		}
+	}
+	return paths
 }
 
 func (k *Kubeconfig) Bytes() ([]byte, error) {

--- a/internal/kubeconfig/kubeconfigloader.go
+++ b/internal/kubeconfig/kubeconfigloader.go
@@ -29,7 +29,12 @@ var (
 
 type StandardKubeconfigLoader struct{}
 
-type kubeconfigFile struct{ *os.File }
+type kubeconfigFile struct {
+	*os.File
+	path string
+}
+
+func (kf *kubeconfigFile) Path() string { return kf.path }
 
 func (*StandardKubeconfigLoader) Load() ([]ReadWriteResetCloser, error) {
 	paths, err := kubeconfigPaths()
@@ -46,7 +51,7 @@ func (*StandardKubeconfigLoader) Load() ([]ReadWriteResetCloser, error) {
 			}
 			return nil, fmt.Errorf("failed to open file %q: %w", p, err)
 		}
-		files = append(files, &kubeconfigFile{f})
+		files = append(files, &kubeconfigFile{File: f, path: p})
 	}
 	if len(files) == 0 {
 		return nil, fmt.Errorf("kubeconfig file not found: %w",


### PR DESCRIPTION
## Summary

- Fixes exec credential plugins that use relative paths (e.g. `command: ../scripts/get-token.sh`) failing with `no such file or directory` in kubens
- Threads the kubeconfig file path through a `PathHinter` interface so `newKubernetesClientSet` can use `clientcmd.NewNonInteractiveDeferredLoadingClientConfig` with file paths, which resolves relative paths relative to the kubeconfig directory — matching kubectl's behavior
- Falls back to the existing bytes-based `RESTConfigFromKubeConfig` for in-memory configs (tests)

## Test plan

- [x] Verified with a kubeconfig using a relative-path exec credential plugin (`command: ../scripts/fake-token.sh`):
  - **Before fix**: `fork/exec ../scripts/fake-token.sh: no such file or directory`
  - **After fix**: script invoked successfully (connection refused, as expected with no real cluster)
- [x] All existing tests pass

Fixes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)